### PR TITLE
Replace ITPWrapper with array-based interp_unsafe and DataBufferType

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /docs/build/
 Manifest.toml
 earthsci_data
+bench/output.json

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,3 +1,8 @@
 [default.extend-words]
 strang = "strang"
 gam = "gam"
+iy = "iy"
+setp = "setp"
+nd = "nd"
+iit = "iit"
+domian = "domian"

--- a/bench/runbenchmarks.jl
+++ b/bench/runbenchmarks.jl
@@ -61,6 +61,54 @@ suite["NEI Simulator"]["Threads"] = @benchmarkable solve(
     initialize_save = false
 )
 
+# -----------------------------------------------------------------------------
+# Microbenchmarks of the interpolation hot path.
+#
+# Compares the full multilinear `interp_unsafe` against the faster
+# `interp_time_only` (nearest-neighbour spatial + linear time), which is used
+# when the model queries the loader at grid-aligned points.  Both wrap the
+# data in `DataBufferType` so the dispatch mirrors what the MTK-generated
+# RHS function runs at each step.
+# -----------------------------------------------------------------------------
+suite["Interpolation hot path"] = BenchmarkGroup()
+
+# Realistic sizes: GEOS-FP 4x5 with ~72 levels, 2-timestep window.
+data4 = rand(Float64, 144, 91, 72, 2)
+data4_db = EarthSciData.DataBufferType(data4)
+fit, fi1, fi2, fi3 = 1.5, 72.3, 45.7, 36.2
+extrap = 1.0
+
+suite["Interpolation hot path"]["4D linear"] = @benchmarkable EarthSciData.interp_unsafe(
+    $data4_db, $fit, $fi1, $fi2, $fi3, $extrap)
+suite["Interpolation hot path"]["4D nearest"] = @benchmarkable EarthSciData.interp_time_only(
+    $data4_db, $fit, $fi1, $fi2, $fi3, $extrap)
+
+# Grid-aligned query (integer spatial indices) — the intended use case for
+# `interp_time_only`.  Both modes should produce the same result here; the
+# benchmark measures the speedup the `:nearest` mode gives for this access
+# pattern.
+fi1_int, fi2_int, fi3_int = 72.0, 45.0, 36.0
+suite["Interpolation hot path"]["4D linear (grid-aligned)"] = @benchmarkable EarthSciData.interp_unsafe(
+    $data4_db, $fit, $fi1_int, $fi2_int, $fi3_int, $extrap)
+suite["Interpolation hot path"]["4D nearest (grid-aligned)"] = @benchmarkable EarthSciData.interp_time_only(
+    $data4_db, $fit, $fi1_int, $fi2_int, $fi3_int, $extrap)
+
+# 3D (2 spatial + time) — emissions grids.
+data3 = rand(Float64, 144, 91, 2)
+data3_db = EarthSciData.DataBufferType(data3)
+suite["Interpolation hot path"]["3D linear"] = @benchmarkable EarthSciData.interp_unsafe(
+    $data3_db, $fit, $fi1, $fi2, $extrap)
+suite["Interpolation hot path"]["3D nearest"] = @benchmarkable EarthSciData.interp_time_only(
+    $data3_db, $fit, $fi1, $fi2, $extrap)
+
+# 2D (1 spatial + time).
+data2 = rand(Float64, 144, 2)
+data2_db = EarthSciData.DataBufferType(data2)
+suite["Interpolation hot path"]["2D linear"] = @benchmarkable EarthSciData.interp_unsafe(
+    $data2_db, $fit, $fi1, $extrap)
+suite["Interpolation hot path"]["2D nearest"] = @benchmarkable EarthSciData.interp_time_only(
+    $data2_db, $fit, $fi1, $extrap)
+
 tune!(suite, verbose = true)
 results = run(suite, verbose = true)
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -12,7 +12,11 @@ makedocs(;
         prettyurls = get(ENV, "CI", "false") == "true",
         canonical = "https://earthsciml.github.io/EarthSciData.jl",
         assets = String[],
-        repolink = "https://github.com/EarthSciML/EarthSciData.jl"
+        repolink = "https://github.com/EarthSciML/EarthSciData.jl",
+        # The NEI and GEOS-FP pages have large equation tables; raise the
+        # thresholds so Documenter's inline-HTML size checks pass.
+        size_threshold = 300 * 2^10,
+        size_threshold_warn = 200 * 2^10
     ),
     pages = [
         "Home" => "index.md",

--- a/docs/src/edgar_v81.md
+++ b/docs/src/edgar_v81.md
@@ -27,7 +27,7 @@ domain = DomainInfo(
     DateTime(2020, 6, 1), DateTime(2020, 7, 1);
     lonrange = deg2rad(-10.0):deg2rad(2.5):deg2rad(30.0),
     latrange = deg2rad(40.0):deg2rad(2):deg2rad(60.0),
-    levrange = 1:10,
+    levrange = 1:10
 )
 
 emis = EDGARv81MonthlyEmis("NOx", "POWER_INDUSTRY", domain)

--- a/docs/src/era5.md
+++ b/docs/src/era5.md
@@ -18,9 +18,10 @@ ERA5
 
 To download ERA5 data automatically, you need a free CDS account:
 
-1. Register at [https://cds.climate.copernicus.eu/](https://cds.climate.copernicus.eu/)
-2. Accept the ERA5 data licence
-3. Create `~/.cdsapirc` with:
+ 1. Register at [https://cds.climate.copernicus.eu/](https://cds.climate.copernicus.eu/)
+ 2. Accept the ERA5 data licence
+ 3. Create `~/.cdsapirc` with:
+
 ```
 url: https://cds.climate.copernicus.eu/api
 key: <your-api-key>
@@ -69,10 +70,11 @@ era5_vars = Dict( # hide
     "clwc" => ("kg kg**-1", "Specific cloud liquid water content", 0.0, 1e-5), # hide
     "crwc" => ("kg kg**-1", "Specific rain water content", 0.0, 1e-5), # hide
     "cswc" => ("kg kg**-1", "Specific snow water content", 0.0, 1e-5), # hide
-    "pv" => ("K m**2 kg**-1 s**-1", "Potential vorticity", -1e-5, 1e-5), # hide
+    "pv" => ("K m**2 kg**-1 s**-1", "Potential vorticity", -1e-5, 1e-5) # hide
 ) # hide
 NCDataset(joinpath(era5_dir, "era5_pl_2022_01.nc"), "c") do ds # hide
-    nlon, nlat, nplev, ntime = length(lon_vals), length(lat_vals), length(plev_vals), length(time_vals) # hide
+    nlon, nlat,
+    nplev, ntime = length(lon_vals), length(lat_vals), length(plev_vals), length(time_vals) # hide
     defDim(ds, "longitude", nlon) # hide
     defDim(ds, "latitude", nlat) # hide
     defDim(ds, "pressure_level", nplev) # hide
@@ -82,13 +84,14 @@ NCDataset(joinpath(era5_dir, "era5_pl_2022_01.nc"), "c") do ds # hide
     defVar(ds, "pressure_level", Float64, ("pressure_level",))[:] = plev_vals # hide
     nctime = defVar(ds, "valid_time", Float64, ("valid_time",), # hide
         attrib = Dict("units" => "hours since 1900-01-01 00:00:00", # hide
-                      "calendar" => "proleptic_gregorian")) # hide
+            "calendar" => "proleptic_gregorian")) # hide
     nctime[:] = time_vals # hide
     for (vname, (units, long_name, vmin, vmax)) in era5_vars # hide
         ncvar = defVar(ds, vname, Float32, # hide
             ("longitude", "latitude", "pressure_level", "valid_time"), # hide
             attrib = Dict("units" => units, "long_name" => long_name)) # hide
-        data = [Float32(vmin + (vmax - vmin) * (i + j + k + ti) / (nlon + nlat + nplev + ntime)) # hide
+        data = [Float32(vmin +
+                        (vmax - vmin) * (i + j + k + ti) / (nlon + nlat + nplev + ntime)) # hide
                 for i in 1:nlon, j in 1:nlat, k in 1:nplev, ti in 1:ntime] # hide
         ncvar[:, :, :, :] = data # hide
     end # hide
@@ -107,10 +110,10 @@ using DynamicQuantities: dimension
 domain = DomainInfo(DateTime(2022, 1, 1), DateTime(2022, 1, 3);
     latrange = deg2rad(20.0f0):deg2rad(5.0):deg2rad(50.0f0),
     lonrange = deg2rad(-130.0f0):deg2rad(5.0):deg2rad(-60.0f0),
-    levrange = 1:4,
+    levrange = 1:4
 )
 
-era5 = ERA5(domain; mirror="file://$(era5_dir)")
+era5 = ERA5(domain; mirror = "file://$(era5_dir)")
 ```
 
 ### State Variables
@@ -134,47 +137,47 @@ eqs = equations(era5)
 
 ERA5 pressure-level variables include:
 
-| Short Name | Long Name | Units |
-|:-----------|:----------|:------|
-| t | Temperature | K |
-| u | U component of wind | m s⁻¹ |
-| v | V component of wind | m s⁻¹ |
-| w | Vertical velocity | Pa s⁻¹ |
-| q | Specific humidity | kg kg⁻¹ |
-| r | Relative humidity | % |
-| z | Geopotential | m² s⁻² |
-| d | Divergence | s⁻¹ |
-| vo | Vorticity | s⁻¹ |
-| o3 | Ozone mass mixing ratio | kg kg⁻¹ |
-| cc | Fraction of cloud cover | (0-1) |
-| ciwc | Specific cloud ice water content | kg kg⁻¹ |
-| clwc | Specific cloud liquid water content | kg kg⁻¹ |
-| crwc | Specific rain water content | kg kg⁻¹ |
-| cswc | Specific snow water content | kg kg⁻¹ |
-| pv | Potential vorticity | K m² kg⁻¹ s⁻¹ |
+| Short Name | Long Name                           | Units         |
+|:---------- |:----------------------------------- |:------------- |
+| t          | Temperature                         | K             |
+| u          | U component of wind                 | m s⁻¹         |
+| v          | V component of wind                 | m s⁻¹         |
+| w          | Vertical velocity                   | Pa s⁻¹        |
+| q          | Specific humidity                   | kg kg⁻¹       |
+| r          | Relative humidity                   | %             |
+| z          | Geopotential                        | m² s⁻²        |
+| d          | Divergence                          | s⁻¹           |
+| vo         | Vorticity                           | s⁻¹           |
+| o3         | Ozone mass mixing ratio             | kg kg⁻¹       |
+| cc         | Fraction of cloud cover             | (0-1)         |
+| ciwc       | Specific cloud ice water content    | kg kg⁻¹       |
+| clwc       | Specific cloud liquid water content | kg kg⁻¹       |
+| crwc       | Specific rain water content         | kg kg⁻¹       |
+| cswc       | Specific snow water content         | kg kg⁻¹       |
+| pv         | Potential vorticity                 | K m² kg⁻¹ s⁻¹ |
 
 ## Pressure Levels
 
 ERA5 provides data on 37 pressure levels from 1000 hPa (surface) to 1 hPa (stratosphere). The level index maps to pressure as follows:
 
 | Index | Pressure (hPa) | Index | Pressure (hPa) |
-|:------|:---------------|:------|:---------------|
-| 1 | 1000 | 20 | 300 |
-| 2 | 975 | 21 | 250 |
-| 3 | 950 | 22 | 225 |
-| 4 | 925 | 23 | 200 |
-| 5 | 900 | 24 | 175 |
-| 6 | 875 | 25 | 150 |
-| 7 | 850 | 26 | 125 |
-| 8 | 825 | 27 | 100 |
-| 9 | 800 | 28 | 70 |
-| 10 | 775 | 29 | 50 |
-| 11 | 750 | 30 | 30 |
-| 12 | 700 | 31 | 20 |
-| 13 | 650 | 32 | 10 |
-| 14 | 600 | 33 | 7 |
-| 15 | 550 | 34 | 5 |
-| 16 | 500 | 35 | 3 |
-| 17 | 450 | 36 | 2 |
-| 18 | 400 | 37 | 1 |
-| 19 | 350 | | |
+|:----- |:-------------- |:----- |:-------------- |
+| 1     | 1000           | 20    | 300            |
+| 2     | 975            | 21    | 250            |
+| 3     | 950            | 22    | 225            |
+| 4     | 925            | 23    | 200            |
+| 5     | 900            | 24    | 175            |
+| 6     | 875            | 25    | 150            |
+| 7     | 850            | 26    | 125            |
+| 8     | 825            | 27    | 100            |
+| 9     | 800            | 28    | 70             |
+| 10    | 775            | 29    | 50             |
+| 11    | 750            | 30    | 30             |
+| 12    | 700            | 31    | 20             |
+| 13    | 650            | 32    | 10             |
+| 14    | 600            | 33    | 7              |
+| 15    | 550            | 34    | 5              |
+| 16    | 500            | 35    | 3              |
+| 17    | 450            | 36    | 2              |
+| 18    | 400            | 37    | 1              |
+| 19    | 350            |       |                |

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -22,8 +22,9 @@ This package contains data loaders for use with the [EarthSciML](https://earthsc
   - Loader for [GEOS-FP](https://gmao.gsfc.nasa.gov/GMAO_products/NRT_products.php) data.
 
   - Loader for [2016 NEI](https://gaftp.epa.gov/Air/) emissions data.
+
   - Data outputters:
-    
+
       + [`NetCDFOutputter`](@ref)
 
 ## Contributing

--- a/docs/src/openaq.md
+++ b/docs/src/openaq.md
@@ -10,18 +10,18 @@
 
 ### Available Parameters
 
-| Parameter | Description |
-|-----------|-------------|
-| `pm25` | Particulate matter (PM2.5) |
-| `pm10` | Particulate matter (PM10) |
-| `o3` | Ozone |
-| `no2` | Nitrogen dioxide |
-| `so2` | Sulfur dioxide |
-| `co` | Carbon monoxide |
-| `bc` | Black carbon |
-| `pm1` | Particulate matter (PM1) |
-| `no` | Nitric oxide |
-| `nox` | Nitrogen oxides |
+| Parameter | Description                |
+|:--------- |:-------------------------- |
+| `pm25`    | Particulate matter (PM2.5) |
+| `pm10`    | Particulate matter (PM10)  |
+| `o3`      | Ozone                      |
+| `no2`     | Nitrogen dioxide           |
+| `so2`     | Sulfur dioxide             |
+| `co`      | Carbon monoxide            |
+| `bc`      | Black carbon               |
+| `pm1`     | Particulate matter (PM1)   |
+| `no`      | Nitric oxide               |
+| `nox`     | Nitrogen oxides            |
 
 ```@docs
 OpenAQ
@@ -31,17 +31,18 @@ OpenAQ
 
 ### Data Flow
 
-1. **Station Discovery**: The OpenAQ API is queried to find all monitoring stations within the model domain's bounding box that measure the requested parameter. Results are cached locally as JSON files.
+ 1. **Station Discovery**: The OpenAQ API is queried to find all monitoring stations within the model domain's bounding box that measure the requested parameter. Results are cached locally as JSON files.
 
-2. **Data Download**: Daily gzip-compressed CSV files are downloaded from the OpenAQ S3 archive for each station. Files are cached locally under `$EARTHSCIDATADIR/openaq_data/`.
+ 2. **Data Download**: Daily gzip-compressed CSV files are downloaded from the OpenAQ S3 archive for each station. Files are cached locally under `$EARTHSCIDATADIR/openaq_data/`.
 
-3. **Point-to-Grid Mapping**: For each hourly time step, measurements from all stations are binned into model grid cells:
-   - Each station is assigned to the grid cell that contains its coordinates
-   - Multiple stations within the same cell are averaged
-   - Multiple readings from the same station within one hour are averaged
-   - Grid cells with no stations receive a configurable fill value (default `NaN`)
+ 3. **Point-to-Grid Mapping**: For each hourly time step, measurements from all stations are binned into model grid cells:
 
-4. **Unit Conversion**: OpenAQ data (typically in µg/m³) is converted to SI units (kg/m³) using the standard EarthSciData.jl unit conversion system.
+      + Each station is assigned to the grid cell that contains its coordinates
+      + Multiple stations within the same cell are averaged
+      + Multiple readings from the same station within one hour are averaged
+      + Grid cells with no stations receive a configurable fill value (default `NaN`)
+
+ 4. **Unit Conversion**: OpenAQ data (typically in µg/m³) is converted to SI units (kg/m³) using the standard EarthSciData.jl unit conversion system.
 
 ### Authentication
 

--- a/docs/src/usgs3dep.md
+++ b/docs/src/usgs3dep.md
@@ -25,10 +25,10 @@ domain = DomainInfo(
     DateTime(2018, 11, 8), DateTime(2018, 11, 9);
     lonrange = deg2rad(-121.7):deg2rad(0.01):deg2rad(-121.5),
     latrange = deg2rad(39.7):deg2rad(0.01):deg2rad(39.8),
-    levrange = 1:1,
+    levrange = 1:1
 )
 
-elev = USGS3DEP(domain; resolution=10.0)
+elev = USGS3DEP(domain; resolution = 10.0)
 ```
 
 ### Variables
@@ -63,15 +63,16 @@ eqs = equations(elev)
 
 ## How It Works
 
-1. **Bounding box**: The spatial extent of the domain is converted to a WGS84 (EPSG:4326) longitude/latitude bounding box with a one-pixel buffer.
+ 1. **Bounding box**: The spatial extent of the domain is converted to a WGS84 (EPSG:4326) longitude/latitude bounding box with a one-pixel buffer.
 
-2. **Download**: A single GeoTIFF tile covering the bounding box is requested from the USGS ImageServer `exportImage` endpoint. Pixel dimensions are computed from the requested resolution, capped at 1000x1000 to limit download size. The tile is cached locally.
+ 2. **Download**: A single GeoTIFF tile covering the bounding box is requested from the USGS ImageServer `exportImage` endpoint. Pixel dimensions are computed from the requested resolution, capped at 1000x1000 to limit download size. The tile is cached locally.
 
-3. **Coordinate mapping**: Pixel-centre coordinates are computed analytically from the bounding box and pixel dimensions (no GeoTIFF metadata parsing needed). Coordinates are stored in radians for consistency with the EarthSciML coordinate system.
+ 3. **Coordinate mapping**: Pixel-centre coordinates are computed analytically from the bounding box and pixel dimensions (no GeoTIFF metadata parsing needed). Coordinates are stored in radians for consistency with the EarthSciML coordinate system.
 
-4. **Interpolation**: The elevation field is provided as a `DataSetInterpolator` that maps simulation coordinates to elevation values via bilinear interpolation.
+ 4. **Interpolation**: The elevation field is provided as a `DataSetInterpolator` that maps simulation coordinates to elevation values via bilinear interpolation.
 
 ## Coverage
 
 !!! warning "US coverage only"
+
     3DEP provides elevation data for the United States only. If the domain falls outside US coverage, a warning is issued and the returned data may contain nodata values. Approximate coverage bounds: longitude -180 to -60, latitude 17 to 72.

--- a/src/EarthSciData.jl
+++ b/src/EarthSciData.jl
@@ -38,8 +38,4 @@ include("landfire.jl")
 # Coupling
 include("coupling.jl")
 
-function __init__()
-    _fix_ifelse_promote_shape()
-end
-
 end

--- a/src/EarthSciData.jl
+++ b/src/EarthSciData.jl
@@ -38,4 +38,8 @@ include("landfire.jl")
 # Coupling
 include("coupling.jl")
 
+function __init__()
+    _fix_ifelse_promote_shape()
+end
+
 end

--- a/src/NCEP-NCAR_Reanalysis.jl
+++ b/src/NCEP-NCAR_Reanalysis.jl
@@ -186,12 +186,13 @@ function get_geometry(::NCEPNCARReanalysisFileSet, m::MetaData)
     nx, ny = length(lon), length(lat)
     polys = Vector{Vector{NTuple{2, Float64}}}(undef, nx * ny)
     for j in 1:ny, i in 1:nx
+
         polys[(j - 1) * nx + i] = [
             (lon_edges[i], lat_edges[j]),
             (lon_edges[i + 1], lat_edges[j]),
             (lon_edges[i + 1], lat_edges[j + 1]),
             (lon_edges[i], lat_edges[j + 1]),
-            (lon_edges[i], lat_edges[j]),
+            (lon_edges[i], lat_edges[j])
         ]
     end
     return polys
@@ -213,7 +214,7 @@ function NCEPNCARReanalysis(
         mirror::String,
         domaininfo::DomainInfo;
         name = :NCEPNCARReanalysis,
-        stream = true,
+        stream = true
 )
     starttime, endtime = get_tspan_datetime(domaininfo)
     fs = NCEPNCARReanalysisFileSet(mirror, domaininfo)

--- a/src/NCEP-NCAR_Reanalysis.jl
+++ b/src/NCEP-NCAR_Reanalysis.jl
@@ -210,11 +210,23 @@ struct NCEPNCARReanalysisCoupler
     sys::Any
 end
 
+"""
+$(SIGNATURES)
+
+A data loader for NCEP/NCAR Reanalysis data.
+
+`stream` specifies whether the data should be streamed in as needed or loaded all at once.
+
+`spatial_interp = :linear` (default) does full multilinear interpolation; `:nearest` does
+spatial nearest-neighbour + time-only linear interpolation for ~8x speedup when queries
+are always at grid points.
+"""
 function NCEPNCARReanalysis(
         mirror::String,
         domaininfo::DomainInfo;
         name = :NCEPNCARReanalysis,
-        stream = true
+        stream = true,
+        spatial_interp::Symbol = :linear
 )
     starttime, endtime = get_tspan_datetime(domaininfo)
     fs = NCEPNCARReanalysisFileSet(mirror, domaininfo)
@@ -256,8 +268,11 @@ function NCEPNCARReanalysis(
             @assert translated_dim ∈ keys(pvdict) "Dimension $d (translated to $translated_dim) is not in the domaininfo coordinates ($(pvs))."
             push!(coords, pvdict[translated_dim])
         end
-        eq, discretes, constants, info = create_interp_equation(
-            itp, "", t, t_ref, coords)
+        eq, discretes,
+        constants,
+        info = create_interp_equation(
+            itp, "", t, t_ref, coords;
+            spatial_interp = spatial_interp)
         push!(eqs, eq)
         append!(all_discretes, discretes)
         append!(all_constants, constants)

--- a/src/NCEP-NCAR_Reanalysis.jl
+++ b/src/NCEP-NCAR_Reanalysis.jl
@@ -213,7 +213,7 @@ function NCEPNCARReanalysis(
         mirror::String,
         domaininfo::DomainInfo;
         name = :NCEPNCARReanalysis,
-        stream = true
+        stream = true,
 )
     starttime, endtime = get_tspan_datetime(domaininfo)
     fs = NCEPNCARReanalysisFileSet(mirror, domaininfo)
@@ -224,7 +224,10 @@ function NCEPNCARReanalysis(
     @parameters t_ref=get_tref(domaininfo) [unit = u"s", description = "Reference time"]
     eqs = Equation[]
     params = Any[t_ref]
-    vars = Num[]
+    all_discretes = Any[]
+    all_constants = Any[]
+    interp_infos = []
+    lhs_vars = Num[]
 
     xdim = :x in keys(pvdict) ? :x : :lon
     ydim = :y in keys(pvdict) ? :y : :lat
@@ -252,13 +255,16 @@ function NCEPNCARReanalysis(
             @assert translated_dim ∈ keys(pvdict) "Dimension $d (translated to $translated_dim) is not in the domaininfo coordinates ($(pvs))."
             push!(coords, pvdict[translated_dim])
         end
-        eq, param = create_interp_equation(itp, "", t, t_ref, coords)
+        eq, discretes, constants, info = create_interp_equation(
+            itp, "", t, t_ref, coords)
         push!(eqs, eq)
-        push!(params, param)
-        push!(vars, eq.lhs)
+        append!(all_discretes, discretes)
+        append!(all_constants, constants)
+        push!(interp_infos, info)
+        push!(lhs_vars, eq.lhs)
 
         if varname == :hgt
-            z_params["hgt"] = param
+            z_params["hgt"] = info
             z_params["hgt_coords"] = coords
         end
     end
@@ -277,7 +283,7 @@ function NCEPNCARReanalysis(
         lon_trans = δxδlon ~ lon2m * cos(pvdict[:lat])
         lat_trans = δyδlat ~ lat2meters
         push!(eqs, lon_trans, lat_trans)
-        push!(vars, δxδlon, δyδlat)
+        push!(lhs_vars, δxδlon, δyδlat)
     end
 
     if :lev in keys(pvdict)
@@ -286,7 +292,7 @@ function NCEPNCARReanalysis(
 
         p_expr = p ~ hPa2Pa * build_pressure_expr(pvdict[:lev])
         push!(eqs, p_expr)
-        push!(vars, p)
+        push!(lhs_vars, p)
     end
 
     @constants Rd=287.05 [unit = u"J/(kg*K)"]
@@ -297,38 +303,39 @@ function NCEPNCARReanalysis(
     p_val = hPa2Pa * build_pressure_expr(pvdict[:lev])
     w_expr = wwnd ~ -omega / (p_val / (Rd * T) * g)
     push!(eqs, w_expr)
-    push!(vars, wwnd)
+    push!(lhs_vars, wwnd)
 
     if haskey(z_params, "hgt")
         @variables δzδlev(t) [
             unit = u"m",
             description = "Height derivative with respect to vertical level"
         ]
-        hgt = z_params["hgt"]
+        hgt_info = z_params["hgt"]
         hgtc = z_params["hgt_coords"]
 
-        Δhgt = hgt(t + t_ref, hgtc[1], hgtc[2], hgtc[3] + 1) - hgt(t + t_ref, hgtc...)
+        Δhgt = build_interp_expr(hgt_info, t + t_ref, [hgtc[1], hgtc[2], hgtc[3] + 1]) -
+               build_interp_expr(hgt_info, t + t_ref, hgtc)
 
         lev_trans = δzδlev ~ Δhgt
         push!(eqs, lev_trans)
-        push!(vars, δzδlev)
+        push!(lhs_vars, δzδlev)
     end
 
     all_params = [
         pvdict[xdim], pvdict[ydim], pvdict[:lev],
         (:lat in keys(pvdict) ? [lat2meters, lon2m] : [])...,
         hPa2Pa, Rd, g,
-        params...
+        all_constants..., all_discretes..., params...
     ]
     sys = System(
         eqs,
         t,
-        vars,
+        lhs_vars,
         all_params;
         name = name,
         initial_conditions = _itp_defaults(all_params),
+        discrete_events = [build_interp_event(interp_infos, starttime)],
         metadata = Dict(CoupleType => NCEPNCARReanalysisCoupler,
-            SysDiscreteEvent => create_updater_sys_event(name, params, starttime),
             SysDomainInfo => domaininfo)
     )
     return sys

--- a/src/cds_api.jl
+++ b/src/cds_api.jl
@@ -41,13 +41,13 @@ Submit a CDS API retrieve request and return the job ID.
 `dataset` is the CDS dataset identifier (e.g. "reanalysis-era5-pressure-levels").
 `request` is a Dict with the request parameters.
 """
-function cds_submit(dataset::AbstractString, request::Dict; api_key::AbstractString=cds_api_key())
+function cds_submit(dataset::AbstractString, request::Dict; api_key::AbstractString = cds_api_key())
     url = "$(CDS_API_URL)/retrieve/v1/processes/$(dataset)/execution"
     body = JSON3.write(Dict("inputs" => request))
 
     headers = [
         "PRIVATE-TOKEN" => api_key,
-        "Content-Type" => "application/json",
+        "Content-Type" => "application/json"
     ]
     resp = _cds_http_post(url, body, headers)
     data = JSON3.read(resp)
@@ -64,8 +64,8 @@ $(SIGNATURES)
 
 Poll a CDS API job until completion. Returns the download URL.
 """
-function cds_wait(job_id::AbstractString; api_key::AbstractString=cds_api_key(),
-                  poll_interval::Real=CDS_POLL_INTERVAL, timeout::Real=CDS_TIMEOUT)
+function cds_wait(job_id::AbstractString; api_key::AbstractString = cds_api_key(),
+        poll_interval::Real = CDS_POLL_INTERVAL, timeout::Real = CDS_TIMEOUT)
     url = "$(CDS_API_URL)/retrieve/v1/jobs/$(job_id)"
     headers = ["PRIVATE-TOKEN" => api_key]
     start_time = time()
@@ -97,17 +97,17 @@ Submit a CDS API request, wait for completion, and download the result.
 Returns the local file path.
 """
 function cds_retrieve(dataset::AbstractString, request::Dict, output_path::AbstractString;
-                      api_key::AbstractString=cds_api_key())
+        api_key::AbstractString = cds_api_key())
     if isfile(output_path)
         return output_path
     end
     mkpath(dirname(output_path))
 
     @info "Submitting CDS API request for $(dataset)..."
-    job_id = cds_submit(dataset, request; api_key=api_key)
+    job_id = cds_submit(dataset, request; api_key = api_key)
     @info "CDS API job submitted: $(job_id). Waiting for completion..."
 
-    download_url = cds_wait(job_id; api_key=api_key)
+    download_url = cds_wait(job_id; api_key = api_key)
     @info "Downloading from CDS: $(basename(output_path))"
 
     _download_with_progress(download_url, output_path)
@@ -117,7 +117,7 @@ end
 # HTTP helpers using Downloads.jl
 function _cds_http_get(url::AbstractString, headers::Vector{<:Pair})
     io = IOBuffer()
-    resp = Downloads.request(url; headers=headers, output=io)
+    resp = Downloads.request(url; headers = headers, output = io)
     body = String(take!(io))
     resp.status >= 400 && error("CDS API HTTP error $(resp.status): $(body)")
     return body
@@ -126,7 +126,8 @@ end
 function _cds_http_post(url::AbstractString, body::AbstractString, headers::Vector{<:Pair})
     io = IOBuffer()
     input = IOBuffer(body)
-    resp = Downloads.request(url; headers=headers, output=io, input=input, method="POST")
+    resp = Downloads.request(
+        url; headers = headers, output = io, input = input, method = "POST")
     resp_body = String(take!(io))
     resp.status >= 400 && error("CDS API HTTP error $(resp.status): $(resp_body)")
     return resp_body

--- a/src/ceds.jl
+++ b/src/ceds.jl
@@ -306,6 +306,9 @@ Sectors (0-7): $(join(["$i: $(CEDS_SECTORS[i+1])" for i in 0:7], "; ")).
   - `data_version`: Data version string. Default is `"v20250421"`.
   - `name`: System name. Default is `:CEDS`.
   - `stream`: Whether to stream data on demand. Default is `true`.
+  - `spatial_interp = :linear` (default) does full multilinear interpolation; `:nearest` does
+    spatial nearest-neighbour + time-only linear interpolation for ~8x speedup when queries
+    are always at grid points.
 """
 function CEDS(
         domaininfo::DomainInfo;
@@ -315,7 +318,8 @@ function CEDS(
         version::AbstractString = "CEDS-CMIP-2025-04-18",
         data_version::AbstractString = "v20250421",
         name = :CEDS,
-        stream = true
+        stream = true,
+        spatial_interp::Symbol = :linear
 )
     for sp in species
         @assert sp in CEDS_SPECIES "Unknown CEDS species '$sp'. Valid: $CEDS_SPECIES"
@@ -346,8 +350,11 @@ function CEDS(
         dt = EarthSciMLBase.eltype(domaininfo)
         itp = DataSetInterpolator{dt}(fs, varname, starttime, endtime, domaininfo;
             stream = stream)
-        eq, discretes, constants, info = create_interp_equation(
-            itp, "", t, t_ref, [x, y])
+        eq, discretes,
+        constants,
+        info = create_interp_equation(
+            itp, "", t, t_ref, [x, y];
+            spatial_interp = spatial_interp)
         push!(eqs, eq)
         append!(all_discretes, discretes)
         append!(all_constants, constants)

--- a/src/ceds.jl
+++ b/src/ceds.jl
@@ -9,12 +9,12 @@ const CEDS_SECTORS = [
     "Residential, Commercial, Other",
     "Solvents production and application",
     "Waste",
-    "International Shipping",
+    "International Shipping"
 ]
 
 # Default bulk emission species available in CEDS.
 const CEDS_SPECIES = [
-    "BC", "CH4", "CO", "CO2", "N2O", "NH3", "NMVOC", "NOx", "OC", "SO2",
+    "BC", "CH4", "CO", "CO2", "N2O", "NH3", "NMVOC", "NOx", "OC", "SO2"
 ]
 
 # Time ranges for the gn (native grid) files as (start_year, end_year) pairs.
@@ -24,7 +24,7 @@ const CEDS_GN_CHUNKS = [
     (1850, 1899),
     (1900, 1949),
     (1950, 1999),
-    (2000, 2023),
+    (2000, 2023)
 ]
 
 """
@@ -111,7 +111,8 @@ struct CEDSFileSet <: FileSet
         filepaths = [maybedownload(fs_temp, DateTime(y1, 1, 1)) for (y1, _) in chunks]
 
         # Open all files as an aggregated dataset and read metadata.
-        ds, lons_deg, lats_rad, dims, fill_val, cftimes = lock(nclock) do
+        ds, lons_deg, lats_rad, dims,
+        fill_val, cftimes = lock(nclock) do
             ds = NCDataset(filepaths, aggdim = "time")
             lons_deg = Float64.(ds["lon"][:])
             lats_rad = deg2rad.(Float64.(ds["lat"][:]))
@@ -133,14 +134,14 @@ struct CEDSFileSet <: FileSet
         time_dim = findfirst(isequal("time"), dims)
         sector_dim_orig = findfirst(isequal("sector"), dims)
         sector_dim = isnothing(sector_dim_orig) ? 0 :
-            sector_dim_orig - (time_dim < sector_dim_orig ? 1 : 0)
+                     sector_dim_orig - (time_dim < sector_dim_orig ? 1 : 0)
         lon_dim_orig = findfirst(isequal("lon"), dims)
         lon_dim = lon_dim_orig - (time_dim < lon_dim_orig ? 1 : 0)
         if sector_dim > 0 && sector_dim < lon_dim
             lon_dim -= 1
         end
         times = [DateTime(Dates.year(ct), Dates.month(ct), Dates.day(ct),
-                          Dates.hour(ct), Dates.minute(ct), Dates.second(ct))
+                     Dates.hour(ct), Dates.minute(ct), Dates.second(ct))
                  for ct in cftimes]
         frequency = Month(1)
         dfi = DataFrequencyInfo(times[1], frequency, times)
@@ -172,7 +173,7 @@ $(SIGNATURES)
 Local cache path for CEDS data files, using a short directory structure
 to avoid exceeding Windows' 260-character MAX_PATH limit.
 """
-function localpath(fs::CEDSFileSet, t::DateTime, varname=nothing)
+function localpath(fs::CEDSFileSet, t::DateTime, varname = nothing)
     year = Dates.year(t)
     y1, y2 = _ceds_chunk_for_year(year)
     filename = "$(fs.species)-em-anthro_$(fs.version)_gn_$(lpad(y1,4,'0'))01-$(lpad(y2,4,'0'))12.nc"
@@ -214,7 +215,7 @@ function loadslice!(
         if fs.sector_dim == 0
             data .= selectdim(raw, fs.lon_dim, fs.lon_perm)
         elseif isnothing(fs.sectors)
-            result = dropdims(sum(raw; dims=fs.sector_dim); dims=fs.sector_dim)
+            result = dropdims(sum(raw; dims = fs.sector_dim); dims = fs.sector_dim)
             data .= selectdim(result, fs.lon_dim, fs.lon_perm)
         else
             # Sum selected sectors directly into data.
@@ -272,9 +273,10 @@ function varnames(fs::CEDSFileSet)
     ["$(fs.species)_em_anthro"]
 end
 
-Base.close(fs::CEDSFileSet) = lock(nclock) do
-    close(fs.ds)
-end
+Base.close(fs::CEDSFileSet) =
+    lock(nclock) do
+        close(fs.ds)
+    end
 
 struct CEDSCoupler
     sys::Any
@@ -297,13 +299,13 @@ Sectors (0-7): $(join(["$i: $(CEDS_SECTORS[i+1])" for i in 0:7], "; ")).
 
 ## Keyword Arguments
 
-- `species`: Vector of species to load. Default is all: `$(CEDS_SPECIES)`.
-- `sectors`: Vector of sector indices (0-7) to include, or `nothing` for all (default).
-- `mirror`: Base URL for data download. Default is the ORNL ESGF THREDDS server.
-- `version`: CEDS source version. Default is `"CEDS-CMIP-2025-04-18"`.
-- `data_version`: Data version string. Default is `"v20250421"`.
-- `name`: System name. Default is `:CEDS`.
-- `stream`: Whether to stream data on demand. Default is `true`.
+  - `species`: Vector of species to load. Default is all: `$(CEDS_SPECIES)`.
+  - `sectors`: Vector of sector indices (0-7) to include, or `nothing` for all (default).
+  - `mirror`: Base URL for data download. Default is the ORNL ESGF THREDDS server.
+  - `version`: CEDS source version. Default is `"CEDS-CMIP-2025-04-18"`.
+  - `data_version`: Data version string. Default is `"v20250421"`.
+  - `name`: System name. Default is `:CEDS`.
+  - `stream`: Whether to stream data on demand. Default is `true`.
 """
 function CEDS(
         domaininfo::DomainInfo;
@@ -313,7 +315,7 @@ function CEDS(
         version::AbstractString = "CEDS-CMIP-2025-04-18",
         data_version::AbstractString = "v20250421",
         name = :CEDS,
-        stream = true,
+        stream = true
 )
     for sp in species
         @assert sp in CEDS_SPECIES "Unknown CEDS species '$sp'. Valid: $CEDS_SPECIES"

--- a/src/ceds.jl
+++ b/src/ceds.jl
@@ -331,7 +331,10 @@ function CEDS(
     @parameters t_ref=get_tref(domaininfo) [unit = u"s", description = "Reference time"]
     eqs = Equation[]
     params = Any[t_ref]
-    vars = Num[]
+    all_discretes = Any[]
+    all_constants = Any[]
+    interp_infos = []
+    lhs_vars = Num[]
 
     for sp in species
         fs = CEDSFileSet(sp, starttime, endtime;
@@ -341,22 +344,25 @@ function CEDS(
         dt = EarthSciMLBase.eltype(domaininfo)
         itp = DataSetInterpolator{dt}(fs, varname, starttime, endtime, domaininfo;
             stream = stream)
-        eq, param = create_interp_equation(itp, "", t, t_ref, [x, y])
+        eq, discretes, constants, info = create_interp_equation(
+            itp, "", t, t_ref, [x, y])
         push!(eqs, eq)
-        push!(params, param)
-        push!(vars, eq.lhs)
+        append!(all_discretes, discretes)
+        append!(all_constants, constants)
+        push!(interp_infos, info)
+        push!(lhs_vars, eq.lhs)
     end
 
-    all_params = [x, y, params...]
+    all_params = [x, y, all_constants..., all_discretes..., params...]
     sys = System(
         eqs,
         t,
-        vars,
+        lhs_vars,
         all_params;
         name = name,
         initial_conditions = _itp_defaults(all_params),
+        discrete_events = [build_interp_event(interp_infos, starttime)],
         metadata = Dict(CoupleType => CEDSCoupler,
-            SysDiscreteEvent => create_updater_sys_event(name, params, starttime),
             SysDomainInfo => domaininfo)
     )
     return sys

--- a/src/coupling.jl
+++ b/src/coupling.jl
@@ -2,12 +2,12 @@
 # Dynamically maps v_lon/v_x → u_wind, v_lat/v_y → v_wind, v_lev → w_wind.
 function _couple_meanwind(mw_sys, met_sys, u_wind, v_wind, w_wind)
     mw_unkn = unknowns(mw_sys)
-    mw_syms = Symbol.([split(string(Symbolics.tosymbol(v, escape=false)), "₊")[end]
-                        for v in mw_unkn])
+    mw_syms = Symbol.([split(string(Symbolics.tosymbol(v, escape = false)), "₊")[end]
+                       for v in mw_unkn])
     wind_targets = Dict(
         :v_lon => u_wind, :v_x => u_wind,
         :v_lat => v_wind, :v_y => v_wind,
-        :v_lev => w_wind,
+        :v_lev => w_wind
     )
     eqs = Equation[]
     for (i, sym) in enumerate(mw_syms)
@@ -33,16 +33,24 @@ function EarthSciMLBase.couple2(c::CEDSCoupler, g::GEOSFPCoupler)
 end
 
 # NEI + GEOSFP
-EarthSciMLBase.couple2(e::NEI2016MonthlyEmisCoupler, g::GEOSFPCoupler) = _couple_emis_to_met(e, g)
+function EarthSciMLBase.couple2(e::NEI2016MonthlyEmisCoupler, g::GEOSFPCoupler)
+    _couple_emis_to_met(e, g)
+end
 
 # EDGAR + GEOSFP
-EarthSciMLBase.couple2(e::EDGARv81MonthlyEmisCoupler, g::GEOSFPCoupler) = _couple_emis_to_met(e, g)
+function EarthSciMLBase.couple2(e::EDGARv81MonthlyEmisCoupler, g::GEOSFPCoupler)
+    _couple_emis_to_met(e, g)
+end
 
 # NEI + ERA5
-EarthSciMLBase.couple2(e::NEI2016MonthlyEmisCoupler, g::ERA5Coupler) = _couple_emis_to_met(e, g)
+function EarthSciMLBase.couple2(e::NEI2016MonthlyEmisCoupler, g::ERA5Coupler)
+    _couple_emis_to_met(e, g)
+end
 
 # EDGAR + ERA5
-EarthSciMLBase.couple2(e::EDGARv81MonthlyEmisCoupler, g::ERA5Coupler) = _couple_emis_to_met(e, g)
+function EarthSciMLBase.couple2(e::EDGARv81MonthlyEmisCoupler, g::ERA5Coupler)
+    _couple_emis_to_met(e, g)
+end
 
 # MeanWind + ERA5
 function EarthSciMLBase.couple2(mw::EarthSciMLBase.MeanWindCoupler, e::ERA5Coupler)

--- a/src/edgar_v81_monthly.jl
+++ b/src/edgar_v81_monthly.jl
@@ -267,6 +267,10 @@ Data spans 2000-2022 and is available from: https://edgar.jrc.ec.europa.eu/datas
 
 `stream` specifies whether the data should be streamed in as needed or loaded all at once.
 
+`spatial_interp = :linear` (default) does full multilinear interpolation; `:nearest` does
+spatial nearest-neighbour + time-only linear interpolation for ~8x speedup when queries
+are always at grid points.
+
 Note: emissions are applied only at the surface level (lev < 2) and converted from
 flux (kg m⁻² s⁻¹) to volumetric rate (kg m⁻³ s⁻¹) by dividing by the first-layer height Δz.
 """
@@ -276,7 +280,8 @@ function EDGARv81MonthlyEmis(
         domaininfo::DomainInfo;
         scale = 1.0,
         name = :EDGARv81MonthlyEmis,
-        stream = true
+        stream = true,
+        spatial_interp::Symbol = :linear
 )
     starttime, endtime = get_tspan_datetime(domaininfo)
     fs = EDGARv81MonthlyEmisFileSet(substance, sector, starttime, endtime)
@@ -308,7 +313,8 @@ function EDGARv81MonthlyEmis(
         eq, discretes,
         constants,
         info = create_interp_equation(itp, "", t, t_ref, [lon, lat];
-            wrapper_f = wrapper_f)
+            wrapper_f = wrapper_f,
+            spatial_interp = spatial_interp)
         push!(eqs, eq)
         append!(all_discretes, discretes)
         append!(all_constants, constants)

--- a/src/edgar_v81_monthly.jl
+++ b/src/edgar_v81_monthly.jl
@@ -273,7 +273,7 @@ function EDGARv81MonthlyEmis(
         domaininfo::DomainInfo;
         scale = 1.0,
         name = :EDGARv81MonthlyEmis,
-        stream = true
+        stream = true,
 )
     starttime, endtime = get_tspan_datetime(domaininfo)
     fs = EDGARv81MonthlyEmisFileSet(substance, sector, starttime, endtime)
@@ -284,12 +284,16 @@ function EDGARv81MonthlyEmis(
     lon = :lon in keys(pvdict) ? pvdict[:lon] : pvdict[:x]
     lat = :lat in keys(pvdict) ? pvdict[:lat] : pvdict[:y]
     lev = pvdict[:lev]
+
     @parameters(Δz=60.0,
         [unit = u"m", description = "Height of the first vertical grid layer"],)
     @parameters t_ref=get_tref(domaininfo) [unit = u"s", description = "Reference time"]
     eqs = Equation[]
     params = Any[t_ref]
-    vars = Num[]
+    all_discretes = Any[]
+    all_constants = Any[]
+    interp_infos = []
+    lhs_vars = Num[]
     for varname in varnames(fs)
         dt = EarthSciMLBase.eltype(domaininfo)
         itp = DataSetInterpolator{dt}(fs, varname, starttime, endtime, domaininfo;
@@ -298,22 +302,25 @@ function EDGARv81MonthlyEmis(
         zero_emis = only(@constants $(ze_name)=0 [unit = units(itp) / u"m"])
         zero_emis = ModelingToolkit.unwrap(zero_emis)
         wrapper_f = (eq) -> ifelse(lev < 2, eq / Δz * scale, zero_emis)
-        eq, param = create_interp_equation(itp, "", t, t_ref, [lon, lat];
+        eq, discretes, constants, info = create_interp_equation(itp, "", t, t_ref, [lon, lat];
             wrapper_f = wrapper_f)
         push!(eqs, eq)
-        push!(params, param, zero_emis)
-        push!(vars, eq.lhs)
+        append!(all_discretes, discretes)
+        append!(all_constants, constants)
+        push!(all_constants, zero_emis)
+        push!(interp_infos, info)
+        push!(lhs_vars, eq.lhs)
     end
-    all_params = [lon, lat, lev, Δz, params...]
+    all_params = [lon, lat, lev, Δz, all_constants..., all_discretes..., params...]
     sys = System(
         eqs,
         t,
-        vars,
+        lhs_vars,
         all_params;
         name = name,
         initial_conditions = _itp_defaults(all_params),
+        discrete_events = [build_interp_event(interp_infos, starttime)],
         metadata = Dict(CoupleType => EDGARv81MonthlyEmisCoupler,
-            SysDiscreteEvent => create_updater_sys_event(name, params, starttime),
             SysDomainInfo => domaininfo)
     )
     return sys

--- a/src/edgar_v81_monthly.jl
+++ b/src/edgar_v81_monthly.jl
@@ -31,7 +31,7 @@ end
 # Internal: find NC files in extract_dir filtered by year range, sorted by year.
 function _find_edgar_nc_files(extract_dir, start_year, end_year)
     all_files = filter(f -> endswith(f, ".nc"), readdir(extract_dir, join = true))
-    pairs = Tuple{Int,String}[]
+    pairs = Tuple{Int, String}[]
     for f in all_files
         yr = _parse_edgar_nc_year(f)
         isnothing(yr) && continue
@@ -92,7 +92,7 @@ struct EDGARv81MonthlyEmisFileSet <: FileSet
     mirror::String
     substance::String
     sector::String
-    ds::Union{NCDataset,NCDatasets.MFDataset}
+    ds::Union{NCDataset, NCDatasets.MFDataset}
     freq_info::DataFrequencyInfo
     extract_dir::String
 
@@ -242,7 +242,10 @@ function varnames(fs::EDGARv81MonthlyEmisFileSet)
     end
 end
 
-Base.close(fs::EDGARv81MonthlyEmisFileSet) = lock(nclock) do; close(fs.ds); end
+Base.close(fs::EDGARv81MonthlyEmisFileSet) =
+    lock(nclock) do ;
+        close(fs.ds);
+    end
 
 struct EDGARv81MonthlyEmisCoupler
     sys::Any
@@ -273,7 +276,7 @@ function EDGARv81MonthlyEmis(
         domaininfo::DomainInfo;
         scale = 1.0,
         name = :EDGARv81MonthlyEmis,
-        stream = true,
+        stream = true
 )
     starttime, endtime = get_tspan_datetime(domaininfo)
     fs = EDGARv81MonthlyEmisFileSet(substance, sector, starttime, endtime)
@@ -302,7 +305,9 @@ function EDGARv81MonthlyEmis(
         zero_emis = only(@constants $(ze_name)=0 [unit = units(itp) / u"m"])
         zero_emis = ModelingToolkit.unwrap(zero_emis)
         wrapper_f = (eq) -> ifelse(lev < 2, eq / Δz * scale, zero_emis)
-        eq, discretes, constants, info = create_interp_equation(itp, "", t, t_ref, [lon, lat];
+        eq, discretes,
+        constants,
+        info = create_interp_equation(itp, "", t, t_ref, [lon, lat];
             wrapper_f = wrapper_f)
         push!(eqs, eq)
         append!(all_discretes, discretes)

--- a/src/era5.jl
+++ b/src/era5.jl
@@ -377,13 +377,18 @@ divergence, vorticity, ozone, cloud fractions, potential vorticity.
 The native data type for this dataset is Float32.
 
 `stream` specifies whether the data should be streamed in as needed or loaded all at once.
+
+`spatial_interp = :linear` (default) does full multilinear interpolation; `:nearest` does
+spatial nearest-neighbour + time-only linear interpolation for ~8x speedup when queries
+are always at grid points.
 """
 function ERA5(
         domaininfo::DomainInfo;
         name = :ERA5,
         mirror::AbstractString = CDS_API_URL,
         variables::Vector{String} = collect(keys(ERA5_VARIABLES)),
-        stream = true
+        stream = true,
+        spatial_interp::Symbol = :linear
 )
     starttime, endtime = get_tspan_datetime(domaininfo)
     fs = ERA5PressureLevelFileSet(domaininfo; mirror = mirror, variables = variables)
@@ -409,8 +414,11 @@ function ERA5(
         # For projected domains, lon→x and lat→y.
         mapped_dims = [get(ERA5_COORD_MAP, dim, Symbol(dim)) for dim in dims]
         coords = _match_domain_coords(mapped_dims, pvdict, pvs)
-        eq, discretes, constants, info = create_interp_equation(
-            itp, "pl", t, t_ref, coords)
+        eq, discretes,
+        constants,
+        info = create_interp_equation(
+            itp, "pl", t, t_ref, coords;
+            spatial_interp = spatial_interp)
         push!(eqs, eq)
         append!(all_discretes, discretes)
         append!(all_constants, constants)

--- a/src/era5.jl
+++ b/src/era5.jl
@@ -385,7 +385,10 @@ function ERA5(
     @parameters t_ref = get_tref(domaininfo) [unit = u"s", description = "Reference time"]
     eqs = Equation[]
     params = Any[t_ref]
-    vars = Num[]
+    all_discretes = Any[]
+    all_constants = Any[]
+    interp_infos = []
+    lhs_vars = Num[]
 
     for varname in varnames(fs)
         dt = EarthSciMLBase.eltype(domaininfo)
@@ -397,10 +400,13 @@ function ERA5(
         # For projected domains, lon→x and lat→y.
         mapped_dims = [get(ERA5_COORD_MAP, dim, Symbol(dim)) for dim in dims]
         coords = _match_domain_coords(mapped_dims, pvdict, pvs)
-        eq, param = create_interp_equation(itp, "pl", t, t_ref, coords)
+        eq, discretes, constants, info = create_interp_equation(
+            itp, "pl", t, t_ref, coords)
         push!(eqs, eq)
-        push!(params, param)
-        push!(vars, eq.lhs)
+        append!(all_discretes, discretes)
+        append!(all_constants, constants)
+        push!(interp_infos, info)
+        push!(lhs_vars, eq.lhs)
     end
 
     # Pressure from level index.
@@ -409,7 +415,7 @@ function ERA5(
     @variables P(t) [unit = u"Pa", description = "Pressure"]
     lev = pvdict[:lev]
     push!(eqs, P ~ hPa2Pa * era5_P_itp(lev))
-    push!(vars, P)
+    push!(lhs_vars, P)
 
     # Coordinate transforms.
     @constants lat2meters = 111.32e3 * 180 / π [unit = u"m/rad"]
@@ -419,14 +425,14 @@ function ERA5(
         @variables δyδlat(t) [unit = u"m/rad", description = "Y gradient with respect to latitude"]
         push!(eqs, δxδlon ~ lon2m * cos(pvdict[:lat]))
         push!(eqs, δyδlat ~ lat2meters)
-        push!(vars, δxδlon, δyδlat)
+        push!(lhs_vars, δxδlon, δyδlat)
     end
 
     # Vertical coordinate transform: δPδlev (change in pressure per level index).
     if :lev in keys(pvdict)
         @variables δPδlev(t) [unit = u"Pa", description = "Pressure gradient with respect to level index"]
         push!(eqs, δPδlev ~ hPa2Pa * DataInterpolations.derivative(era5_P_itp, lev))
-        push!(vars, δPδlev)
+        push!(lhs_vars, δPδlev)
     end
 
     all_params = [
@@ -435,17 +441,17 @@ function ERA5(
         get(pvdict, :lev, nothing),
         hPa2Pa,
         (:lat in keys(pvdict) ? [lat2meters, lon2m] : [])...,
-        params...
+        all_constants..., all_discretes..., params...
     ]
     filter!(!isnothing, all_params)
 
     sys = System(
-        eqs, t, vars, all_params;
+        eqs, t, lhs_vars, all_params;
         name=name,
         initial_conditions = _itp_defaults(all_params),
+        discrete_events = [build_interp_event(interp_infos, starttime)],
         metadata=Dict(
             CoupleType => ERA5Coupler,
-            SysDiscreteEvent => create_updater_sys_event(name, params, starttime),
             SysDomainInfo => domaininfo,
         ),
     )

--- a/src/era5.jl
+++ b/src/era5.jl
@@ -29,7 +29,7 @@ const ERA5_VARIABLES = Dict(
     "specific_cloud_liquid_water_content" => "clwc",
     "specific_rain_water_content" => "crwc",
     "specific_snow_water_content" => "cswc",
-    "potential_vorticity" => "pv",
+    "potential_vorticity" => "pv"
 )
 
 # Dimension name constants to avoid scattered string literals.
@@ -64,8 +64,8 @@ struct ERA5PressureLevelFileSet <: FileSet
     _lon_shift::Int  # circshift amount for 0..360 → -180..180, 0 if no shift needed.
 
     function ERA5PressureLevelFileSet(domaininfo::DomainInfo;
-            mirror::AbstractString=CDS_API_URL,
-            variables::Vector{String}=collect(keys(ERA5_VARIABLES)))
+            mirror::AbstractString = CDS_API_URL,
+            variables::Vector{String} = collect(keys(ERA5_VARIABLES)))
         starttime, endtime = get_tspan_datetime(domaininfo)
 
         is_local = startswith(mirror, "file://")
@@ -118,15 +118,19 @@ struct ERA5PressureLevelFileSet <: FileSet
                 # Also sample edges to capture curvature for large domains.
                 for x in xs
                     lo, la = to_lonlat(x, first(ys))
-                    push!(lon_vals, rad2deg(lo)); push!(lat_vals, rad2deg(la))
+                    push!(lon_vals, rad2deg(lo));
+                    push!(lat_vals, rad2deg(la))
                     lo, la = to_lonlat(x, last(ys))
-                    push!(lon_vals, rad2deg(lo)); push!(lat_vals, rad2deg(la))
+                    push!(lon_vals, rad2deg(lo));
+                    push!(lat_vals, rad2deg(la))
                 end
                 for y in ys
                     lo, la = to_lonlat(first(xs), y)
-                    push!(lon_vals, rad2deg(lo)); push!(lat_vals, rad2deg(la))
+                    push!(lon_vals, rad2deg(lo));
+                    push!(lat_vals, rad2deg(la))
                     lo, la = to_lonlat(last(xs), y)
-                    push!(lon_vals, rad2deg(lo)); push!(lat_vals, rad2deg(la))
+                    push!(lon_vals, rad2deg(lo));
+                    push!(lat_vals, rad2deg(la))
                 end
                 lonrange_deg = extrema(lon_vals)
                 latrange_deg = extrema(lat_vals)
@@ -137,7 +141,7 @@ struct ERA5PressureLevelFileSet <: FileSet
                 ceil(Int, latrange_deg[2] + 1),   # north
                 floor(Int, lonrange_deg[1] - 1),   # west
                 floor(Int, latrange_deg[1] - 1),   # south
-                ceil(Int, lonrange_deg[2] + 1),    # east
+                ceil(Int, lonrange_deg[2] + 1)    # east
             ]
 
             for d in month_dates
@@ -145,19 +149,20 @@ struct ERA5PressureLevelFileSet <: FileSet
                 # Figure out which days in this month we need.
                 month_start = max(Date(yr, mo, 1), Date(t_start))
                 month_end = min(lastdayofmonth(Date(yr, mo, 1)), Date(t_end))
-                days = [lpad(dy, 2, '0') for dy in Dates.day(month_start):Dates.day(month_end)]
+                days = [lpad(dy, 2, '0')
+                        for dy in Dates.day(month_start):Dates.day(month_end)]
 
                 request = Dict(
                     "product_type" => ["reanalysis"],
                     "variable" => variables,
-                    "pressure_level" => [string(p) for p in sort(plevels, rev=true)],
+                    "pressure_level" => [string(p) for p in sort(plevels, rev = true)],
                     "year" => [string(yr)],
                     "month" => [lpad(mo, 2, '0')],
                     "day" => days,
                     "time" => [lpad(h, 2, '0') * ":00" for h in 0:23],
                     "data_format" => "netcdf",
                     "download_format" => "unarchived",
-                    "area" => area,
+                    "area" => area
                 )
 
                 outpath = joinpath(
@@ -165,7 +170,7 @@ struct ERA5PressureLevelFileSet <: FileSet
                     "era5_pressure_levels",
                     "era5_pl_$(yr)_$(lpad(mo, 2, '0')).nc"
                 )
-                cds_retrieve("reanalysis-era5-pressure-levels", request, outpath; api_key=api_key)
+                cds_retrieve("reanalysis-era5-pressure-levels", request, outpath; api_key = api_key)
                 push!(filepaths, outpath)
             end
         end
@@ -174,7 +179,7 @@ struct ERA5PressureLevelFileSet <: FileSet
             ds = if length(filepaths) == 1
                 NCDataset(filepaths[1])
             else
-                NCDataset(filepaths, aggdim=ERA5_TIME_DIM)
+                NCDataset(filepaths, aggdim = ERA5_TIME_DIM)
             end
 
             times = DateTime.(ds[ERA5_TIME_DIM][:])
@@ -184,7 +189,7 @@ struct ERA5PressureLevelFileSet <: FileSet
             # Discover which short-name variables are in the file.
             dim_keys = Set(keys(ds.dim))
             coord_keys = Set([ERA5_TIME_DIM, ERA5_PLEV_DIM, ERA5_LAT_DIM, ERA5_LON_DIM,
-                              "number", "expver"])
+                "number", "expver"])
             varlist = [k for k in keys(ds) if !(k in dim_keys) && !(k in coord_keys)]
 
             # Cache coordinate info for loadslice! hot path.
@@ -205,7 +210,7 @@ struct ERA5PressureLevelFileSet <: FileSet
             end
 
             return new(String(mirror), ds, dfi, varlist,
-                       lat_needs_reverse, plevs_need_reverse, lon_shift_amount)
+                lat_needs_reverse, plevs_need_reverse, lon_shift_amount)
         end
     end
 end
@@ -218,7 +223,10 @@ end
 
 DataFrequencyInfo(fs::ERA5PressureLevelFileSet)::DataFrequencyInfo = fs.freq_info
 
-Base.close(fs::ERA5PressureLevelFileSet) = lock(nclock) do; close(fs.ds); end
+Base.close(fs::ERA5PressureLevelFileSet) =
+    lock(nclock) do ;
+        close(fs.ds);
+    end
 
 function loadslice!(data::AbstractArray, fs::ERA5PressureLevelFileSet, t::DateTime, varname)
     lock(nclock) do
@@ -236,7 +244,7 @@ function loadslice!(data::AbstractArray, fs::ERA5PressureLevelFileSet, t::DateTi
         lat_idx = findfirst(isequal(ERA5_LAT_DIM), dims)
         if lat_idx !== nothing && fs._lat_needs_reverse
             lat_idx_notimedim = lat_idx > time_index ? lat_idx - 1 : lat_idx
-            reverse!(raw, dims=lat_idx_notimedim)
+            reverse!(raw, dims = lat_idx_notimedim)
         end
 
         # ERA5 pressure levels may be stored in ascending order; reverse to match
@@ -244,7 +252,7 @@ function loadslice!(data::AbstractArray, fs::ERA5PressureLevelFileSet, t::DateTi
         plev_idx = findfirst(isequal(ERA5_PLEV_DIM), dims)
         if plev_idx !== nothing && fs._plevs_need_reverse
             plev_idx_notimedim = plev_idx > time_index ? plev_idx - 1 : plev_idx
-            reverse!(raw, dims=plev_idx_notimedim)
+            reverse!(raw, dims = plev_idx_notimedim)
         end
 
         # ERA5 longitude is 0..360; shift to -180..180.
@@ -293,7 +301,7 @@ function loadmetadata(fs::ERA5PressureLevelFileSet, varname)::MetaData
                 # Map pressure levels to integer indices for interpolation.
                 plevs_hpa = Float64.(fs.ds[ERA5_PLEV_DIM][:])
                 # Sort from highest to lowest pressure (surface up).
-                plevs_sorted = sort(plevs_hpa, rev=true)
+                plevs_sorted = sort(plevs_hpa, rev = true)
                 # Map each to its index via precomputed lookup.
                 indices = Float64[]
                 for p in plevs_sorted
@@ -355,8 +363,9 @@ covering 1940 to present with hourly temporal resolution and 0.25deg x 0.25deg s
 on 37 pressure levels.
 
 **Authentication**: Requires a CDS API key. Either:
-- Set `ENV["CDSAPI_KEY"]`
-- Create `~/.cdsapirc` with `url: https://cds.climate.copernicus.eu/api` and `key: <your-key>`
+
+  - Set `ENV["CDSAPI_KEY"]`
+  - Create `~/.cdsapirc` with `url: https://cds.climate.copernicus.eu/api` and `key: <your-key>`
 
 **Pre-downloaded data**: Pass `mirror="file:///path/to/data"` to use local NetCDF files.
 Expected filenames: `era5_pl_YYYY_MM.nc` containing all variables for that month.
@@ -371,13 +380,13 @@ The native data type for this dataset is Float32.
 """
 function ERA5(
         domaininfo::DomainInfo;
-        name=:ERA5,
-        mirror::AbstractString=CDS_API_URL,
-        variables::Vector{String}=collect(keys(ERA5_VARIABLES)),
-        stream=true,
+        name = :ERA5,
+        mirror::AbstractString = CDS_API_URL,
+        variables::Vector{String} = collect(keys(ERA5_VARIABLES)),
+        stream = true
 )
     starttime, endtime = get_tspan_datetime(domaininfo)
-    fs = ERA5PressureLevelFileSet(domaininfo; mirror=mirror, variables=variables)
+    fs = ERA5PressureLevelFileSet(domaininfo; mirror = mirror, variables = variables)
 
     pvs = EarthSciMLBase.pvars(domaininfo)
     pvdict = Dict([Symbol(v) => v for v in pvs]...)
@@ -393,7 +402,7 @@ function ERA5(
     for varname in varnames(fs)
         dt = EarthSciMLBase.eltype(domaininfo)
         itp = DataSetInterpolator{dt}(
-            fs, varname, starttime, endtime, domaininfo; stream=stream
+            fs, varname, starttime, endtime, domaininfo; stream = stream
         )
         dims = dimnames(itp)
         # Map ERA5 dimension names to domain coordinate names.
@@ -421,8 +430,10 @@ function ERA5(
     @constants lat2meters = 111.32e3 * 180 / π [unit = u"m/rad"]
     @constants lon2m = 40075.0e3 / 2π [unit = u"m/rad"]
     if :lat in keys(pvdict)
-        @variables δxδlon(t) [unit = u"m/rad", description = "X gradient with respect to longitude"]
-        @variables δyδlat(t) [unit = u"m/rad", description = "Y gradient with respect to latitude"]
+        @variables δxδlon(t) [
+            unit = u"m/rad", description = "X gradient with respect to longitude"]
+        @variables δyδlat(t) [
+            unit = u"m/rad", description = "Y gradient with respect to latitude"]
         push!(eqs, δxδlon ~ lon2m * cos(pvdict[:lat]))
         push!(eqs, δyδlat ~ lat2meters)
         push!(lhs_vars, δxδlon, δyδlat)
@@ -430,7 +441,8 @@ function ERA5(
 
     # Vertical coordinate transform: δPδlev (change in pressure per level index).
     if :lev in keys(pvdict)
-        @variables δPδlev(t) [unit = u"Pa", description = "Pressure gradient with respect to level index"]
+        @variables δPδlev(t) [
+            unit = u"Pa", description = "Pressure gradient with respect to level index"]
         push!(eqs, δPδlev ~ hPa2Pa * DataInterpolations.derivative(era5_P_itp, lev))
         push!(lhs_vars, δPδlev)
     end
@@ -447,13 +459,13 @@ function ERA5(
 
     sys = System(
         eqs, t, lhs_vars, all_params;
-        name=name,
+        name = name,
         initial_conditions = _itp_defaults(all_params),
         discrete_events = [build_interp_event(interp_infos, starttime)],
-        metadata=Dict(
+        metadata = Dict(
             CoupleType => ERA5Coupler,
-            SysDomainInfo => domaininfo,
-        ),
+            SysDomainInfo => domaininfo
+        )
     )
     return sys
 end
@@ -467,16 +479,17 @@ from `δ(u)/δ(lev)` to `δ(u)/δ(P)`, i.e. from vertical level index
 to pressure in Pa.
 
 Usage (mirrors the GEOSFP pattern):
+
 ```julia
-era5 = ERA5(domain; ...)
+era5 = ERA5(domain)
 domain2 = EarthSciMLBase.add_partial_derivative_func(
     domain,
-    partialderivatives_δPδlev_era5(),
+    partialderivatives_δPδlev_era5()
 )
 composed = couple(sys, domain2, Advection(), era5)
 ```
 """
-function partialderivatives_δPδlev_era5(; default_lev=1.0)
+function partialderivatives_δPδlev_era5(; default_lev = 1.0)
     @constants P_unit = 100.0 [unit = u"Pa", description = "hPa to Pa conversion factor"]
     (pvars::AbstractVector) -> begin
         levindex = EarthSciMLBase.matching_suffix_idx(pvars, :lev)

--- a/src/geosfp.jl
+++ b/src/geosfp.jl
@@ -401,13 +401,18 @@ The native data type for this dataset is Float32.
 
 `stream` specifies whether the data should be streamed in as needed or loaded all at once.
 
+`spatial_interp = :linear` (default) does full multilinear interpolation; `:nearest` does
+spatial nearest-neighbour + time-only linear interpolation for ~8x speedup when queries
+are always at grid points.
+
 See http://geoschemdata.wustl.edu/ExtData/ for current data domain options.
 """
 function GEOSFP(
         domain::AbstractString,
         domaininfo::DomainInfo;
         name = :GEOSFP,
-        stream = true
+        stream = true,
+        spatial_interp::Symbol = :linear
 )
     starttime, endtime = get_tspan_datetime(domaininfo)
     filesets = Dict{String, GEOSFPFileSet}(
@@ -445,8 +450,10 @@ function GEOSFP(
             dims = dimnames(itp)
             coords = _match_domain_coords(dims, pvdict, pvs)
             eq, discretes,
-            constants, info = create_interp_equation(
-                itp, filename, t, t_ref, coords)
+            constants,
+            info = create_interp_equation(
+                itp, filename, t, t_ref, coords;
+                spatial_interp = spatial_interp)
             push!(eqs, eq)
             append!(all_discretes, discretes)
             append!(all_constants, constants)

--- a/src/geosfp.jl
+++ b/src/geosfp.jl
@@ -189,7 +189,10 @@ function varnames(fs::GEOSFPFileSet)
     end
 end
 
-Base.close(fs::GEOSFPFileSet) = lock(nclock) do; close(fs.ds); end
+Base.close(fs::GEOSFPFileSet) =
+    lock(nclock) do ;
+        close(fs.ds);
+    end
 
 # Hybrid grid parameters from https://wiki.seas.harvard.edu/geos-chem/index.php/GEOS-Chem_vertical_grids
 const Ap = DataInterpolations.LinearInterpolation(
@@ -404,7 +407,7 @@ function GEOSFP(
         domain::AbstractString,
         domaininfo::DomainInfo;
         name = :GEOSFP,
-        stream = true,
+        stream = true
 )
     starttime, endtime = get_tspan_datetime(domaininfo)
     filesets = Dict{String, GEOSFPFileSet}(
@@ -441,7 +444,8 @@ function GEOSFP(
             )
             dims = dimnames(itp)
             coords = _match_domain_coords(dims, pvdict, pvs)
-            eq, discretes, constants, info = create_interp_equation(
+            eq, discretes,
+            constants, info = create_interp_equation(
                 itp, filename, t, t_ref, coords)
             push!(eqs, eq)
             append!(all_discretes, discretes)

--- a/src/geosfp.jl
+++ b/src/geosfp.jl
@@ -404,7 +404,7 @@ function GEOSFP(
         domain::AbstractString,
         domaininfo::DomainInfo;
         name = :GEOSFP,
-        stream = true
+        stream = true,
 )
     starttime, endtime = get_tspan_datetime(domaininfo)
     filesets = Dict{String, GEOSFPFileSet}(
@@ -421,7 +421,10 @@ function GEOSFP(
     pvdict = Dict([Symbol(v) => v for v in pvs]...)
     eqs = Equation[]
     params = Any[t_ref]
-    vars = Num[]
+    all_discretes = Any[]
+    all_constants = Any[]
+    interp_infos = []
+    lhs_vars = Num[]
     for (filename, fs) in filesets
         for varname in varnames(fs)
             dt = eltype(domaininfo)
@@ -438,32 +441,35 @@ function GEOSFP(
             )
             dims = dimnames(itp)
             coords = _match_domain_coords(dims, pvdict, pvs)
-            eq, param = create_interp_equation(itp, filename, t, t_ref, coords)
+            eq, discretes, constants, info = create_interp_equation(
+                itp, filename, t, t_ref, coords)
             push!(eqs, eq)
-            push!(params, param)
-            push!(vars, eq.lhs)
+            append!(all_discretes, discretes)
+            append!(all_constants, constants)
+            push!(interp_infos, info)
+            push!(lhs_vars, eq.lhs)
         end
     end
 
     # Implement hybrid grid pressure: https://wiki.seas.harvard.edu/geos-chem/index.php/GEOS-Chem_vertical_grids
     @constants P_unit=1.0 [unit = u"Pa", description = "Unit pressure"]
     @variables P(t) [unit = u"Pa", description = "Pressure"]
-    i3ps = vars[findfirst(isequal(:I3₊PS), EarthSciMLBase.var2symbol.(vars))]
+    i3ps = lhs_vars[findfirst(isequal(:I3₊PS), EarthSciMLBase.var2symbol.(lhs_vars))]
     @assert :lev in keys(pvdict) "GEOSFP coordinate :lev not found in domaininfo coordinates ($(pvs))."
     lev = pvdict[:lev]
     pressure_eq = P ~ P_unit * Ap(lev) + Bp(lev) * i3ps
     push!(eqs, pressure_eq)
-    push!(vars, P)
+    push!(lhs_vars, P)
 
     # ------------------ Geopotential height via hypsometric relation ---------
     @constants Rd = 287.05 [unit = u"J/(kg*K)", description = "Dry-air gas constant"]
     @constants g = 9.80665 [unit = u"m/s^2", description = "Gravity"]
 
-    syms = EarthSciMLBase.var2symbol.(vars)
+    syms = EarthSciMLBase.var2symbol.(lhs_vars)
     getvar(sym::Symbol) = begin
         i = findfirst(isequal(sym), syms)
         @assert !isnothing(i) "Variable $(sym) not found!"
-        vars[i]
+        lhs_vars[i]
     end
 
     T = getvar(:I3₊T)
@@ -488,7 +494,7 @@ function GEOSFP(
     eq_Z_agl = Z_agl ~ (Rd * Tv̄ / g) * log(PS / Pmid)
 
     push!(eqs, eq_Tv, eq_Tv_sfc, eq_Tvbar, eq_Z_agl)
-    push!(vars, Tv, Tv_sfc, Tv̄, Z_agl)
+    push!(lhs_vars, Tv, Tv_sfc, Tv̄, Z_agl)
     # ------------------------------------------------------------------------
 
     # Coordinate transforms.
@@ -506,7 +512,7 @@ function GEOSFP(
         lon_trans = δxδlon ~ lon2m * cos(pvdict[:lat])
         lat_trans = δyδlat ~ lat2meters
         push!(eqs, lon_trans, lat_trans)
-        push!(vars, δxδlon, δyδlat)
+        push!(lhs_vars, δxδlon, δyδlat)
     end
 
     @variables δPδlev(t) [
@@ -515,30 +521,30 @@ function GEOSFP(
     ]
     lev_trans = δPδlev ~ expand_derivatives(Differential(lev)(pressure_eq.rhs))
     push!(eqs, lev_trans)
-    push!(vars, δPδlev)
+    push!(lhs_vars, δPδlev)
 
     @variables δZδlev(t) [unit = u"m", description = "∂Z_agl/∂lev"]
     eq_dZ_dlev = δZδlev ~ expand_derivatives(Differential(lev)(eq_Z_agl.rhs))
     push!(eqs, eq_dZ_dlev)
-    push!(vars, δZδlev)
+    push!(lhs_vars, δZδlev)
 
     all_params = [
         get(pvdict, :lon, get(pvdict, :x, nothing)),
         get(pvdict, :lat, get(pvdict, :y, nothing)),
         lev, P_unit, Rd, g,
         (:lat in keys(pvdict) ? [lat2meters, lon2m] : [])...,
-        params...
+        all_constants..., all_discretes..., params...
     ]
     filter!(!isnothing, all_params)
     sys = System(
         eqs,
         t,
-        vars,
+        lhs_vars,
         all_params;
         name = name,
         initial_conditions = _itp_defaults(all_params),
+        discrete_events = [build_interp_event(interp_infos, starttime)],
         metadata = Dict(CoupleType => GEOSFPCoupler,
-            SysDiscreteEvent => create_updater_sys_event(name, params, starttime),
             SysDomainInfo => domaininfo)
     )
     return sys

--- a/src/landfire.jl
+++ b/src/landfire.jl
@@ -26,20 +26,25 @@ function _domain_bbox_wgs84(domaininfo)
         for x in (first(xs), last(xs))
             for y in (first(ys), last(ys))
                 lo, la = to_lonlat(x, y)
-                push!(lon_vals, rad2deg(lo)); push!(lat_vals, rad2deg(la))
+                push!(lon_vals, rad2deg(lo));
+                push!(lat_vals, rad2deg(la))
             end
         end
         for x in xs
             lo, la = to_lonlat(x, first(ys))
-            push!(lon_vals, rad2deg(lo)); push!(lat_vals, rad2deg(la))
+            push!(lon_vals, rad2deg(lo));
+            push!(lat_vals, rad2deg(la))
             lo, la = to_lonlat(x, last(ys))
-            push!(lon_vals, rad2deg(lo)); push!(lat_vals, rad2deg(la))
+            push!(lon_vals, rad2deg(lo));
+            push!(lat_vals, rad2deg(la))
         end
         for y in ys
             lo, la = to_lonlat(first(xs), y)
-            push!(lon_vals, rad2deg(lo)); push!(lat_vals, rad2deg(la))
+            push!(lon_vals, rad2deg(lo));
+            push!(lat_vals, rad2deg(la))
             lo, la = to_lonlat(last(xs), y)
-            push!(lon_vals, rad2deg(lo)); push!(lat_vals, rad2deg(la))
+            push!(lon_vals, rad2deg(lo));
+            push!(lat_vals, rad2deg(la))
         end
         lon_min, lon_max = extrema(lon_vals)
         lat_min, lat_max = extrema(lat_vals)
@@ -275,7 +280,7 @@ function LANDFIRE(domaininfo::DomainInfo; name = :LANDFIRE,
         discrete_events = [build_interp_event(interp_infos, starttime)],
         metadata = Dict(
             CoupleType => LANDFIRECoupler,
-            SysDomainInfo => domaininfo,
+            SysDomainInfo => domaininfo
         )
     )
     return sys

--- a/src/landfire.jl
+++ b/src/landfire.jl
@@ -260,19 +260,21 @@ function LANDFIRE(domaininfo::DomainInfo; name = :LANDFIRE,
         fswr, "fuel_model", starttime, endtime, domaininfo; stream = stream)
     dims = dimnames(itp)
     coords = _match_domain_coords(dims, pvdict, pvs)
-    eq, param = create_interp_equation(itp, "", t, t_ref, coords)
+    eq, discretes, constants, info = create_interp_equation(
+        itp, "", t, t_ref, coords)
 
-    params = Any[t_ref, param]
-    vars = Num[eq.lhs]
+    all_params = Any[t_ref, constants..., discretes...]
+    interp_infos = [info]
+    lhs_vars = Num[eq.lhs]
     eqs = Equation[eq]
 
     sys = System(
-        eqs, t, vars, params;
+        eqs, t, lhs_vars, all_params;
         name = name,
-        initial_conditions = _itp_defaults(params),
+        initial_conditions = _itp_defaults(all_params),
+        discrete_events = [build_interp_event(interp_infos, starttime)],
         metadata = Dict(
             CoupleType => LANDFIRECoupler,
-            SysDiscreteEvent => create_updater_sys_event(name, params, starttime),
             SysDomainInfo => domaininfo,
         )
     )

--- a/src/landfire.jl
+++ b/src/landfire.jl
@@ -226,6 +226,9 @@ for categorical data).
   - `version`: LANDFIRE version (default `"LF2022"`).
   - `resolution`: Target resolution in arc-seconds (default 1.0 ≈ 30m).
   - `stream`: Whether to stream data lazily (default `true`).
+  - `spatial_interp = :linear` (default) does full multilinear interpolation; `:nearest` does
+    spatial nearest-neighbour + time-only linear interpolation for ~8x speedup when queries
+    are always at grid points.
 
 # Example
 
@@ -241,7 +244,8 @@ fuel = LANDFIRE(domain)
 ```
 """
 function LANDFIRE(domaininfo::DomainInfo; name = :LANDFIRE,
-        product = "FBFM13", version = "LF2022", resolution = 1.0, stream = true)
+        product = "FBFM13", version = "LF2022", resolution = 1.0, stream = true,
+        spatial_interp::Symbol = :linear)
     starttime, endtime = get_tspan_datetime(domaininfo)
     fs = LANDFIREFileSet(domaininfo; product = product, version = version,
         resolution = resolution)
@@ -265,8 +269,11 @@ function LANDFIRE(domaininfo::DomainInfo; name = :LANDFIRE,
         fswr, "fuel_model", starttime, endtime, domaininfo; stream = stream)
     dims = dimnames(itp)
     coords = _match_domain_coords(dims, pvdict, pvs)
-    eq, discretes, constants, info = create_interp_equation(
-        itp, "", t, t_ref, coords)
+    eq, discretes,
+    constants,
+    info = create_interp_equation(
+        itp, "", t, t_ref, coords;
+        spatial_interp = spatial_interp)
 
     all_params = Any[t_ref, constants..., discretes...]
     interp_infos = [info]

--- a/src/load.jl
+++ b/src/load.jl
@@ -700,7 +700,8 @@ end
 # error.  We surface it as an assertion via `@boundscheck` so callers can
 # elide the check with `@inbounds` in performance-critical code, and the
 # `@noinline` keeps the throw path off the hot path.
-@noinline _throw_fit_oor(fit, nt) = throw(ArgumentError(
+@noinline _throw_fit_oor(fit,
+    nt) = throw(ArgumentError(
     "Interpolation time index $fit outside loaded cache range [1, $nt]; " *
     "the discrete update event did not refresh the cache for the current integrator time."))
 
@@ -837,6 +838,83 @@ function interp_unsafe(data::AbstractArray{T, 4}, fit, fi1, fi2, fi3, extrap) wh
         end
     end
     return result
+end
+
+# --------------------------------------------------------------------------
+# Fast path: time-only interpolation with nearest-neighbour spatial indexing.
+#
+# Used when the data grid matches the model grid exactly and the caller
+# evaluates at grid points. `fi1..fiN` are assumed to be approximately
+# integer-valued; we round to the nearest index and perform interpolation
+# only in time. This reduces the corner count from 2^(1+dim) to 2.
+# --------------------------------------------------------------------------
+
+"""
+Nearest-neighbour spatial + linear time interpolation on a 2D array.
+`fit` is a fractional 1-based time index; `fi1` is assumed (approximately)
+integer-valued at a grid point.
+"""
+function interp_time_only(data::AbstractArray{T, 2}, fit, fi1, extrap) where {T}
+    n1, nt = size(data)
+    @boundscheck (fit < one(T) || fit > T(nt)) && _throw_fit_oor(fit, nt)
+
+    # Extrapolation check (zero outside range if extrap < 1)
+    if extrap < one(T)
+        if fi1 < one(T) || fi1 > T(n1)
+            return zero(T)
+        end
+    end
+
+    i1 = clamp(unsafe_trunc(Int, fi1 + T(0.5)), 1, n1)
+    it = clamp(unsafe_trunc(Int, fit), 1, nt)
+    wt = fit - T(it)
+    jt = min(it + 1, nt)
+    return (one(T) - wt) * data[i1, it] + wt * data[i1, jt]
+end
+
+"""
+Nearest-neighbour spatial + linear time interpolation on a 3D array.
+"""
+function interp_time_only(data::AbstractArray{T, 3}, fit, fi1, fi2, extrap) where {T}
+    n1, n2, nt = size(data)
+    @boundscheck (fit < one(T) || fit > T(nt)) && _throw_fit_oor(fit, nt)
+
+    if extrap < one(T)
+        if fi1 < one(T) || fi1 > T(n1) || fi2 < one(T) || fi2 > T(n2)
+            return zero(T)
+        end
+    end
+
+    i1 = clamp(unsafe_trunc(Int, fi1 + T(0.5)), 1, n1)
+    i2 = clamp(unsafe_trunc(Int, fi2 + T(0.5)), 1, n2)
+    it = clamp(unsafe_trunc(Int, fit), 1, nt)
+    wt = fit - T(it)
+    jt = min(it + 1, nt)
+    return (one(T) - wt) * data[i1, i2, it] + wt * data[i1, i2, jt]
+end
+
+"""
+Nearest-neighbour spatial + linear time interpolation on a 4D array.
+"""
+function interp_time_only(
+        data::AbstractArray{T, 4}, fit, fi1, fi2, fi3, extrap) where {T}
+    n1, n2, n3, nt = size(data)
+    @boundscheck (fit < one(T) || fit > T(nt)) && _throw_fit_oor(fit, nt)
+
+    if extrap < one(T)
+        if fi1 < one(T) || fi1 > T(n1) || fi2 < one(T) || fi2 > T(n2) ||
+           fi3 < one(T) || fi3 > T(n3)
+            return zero(T)
+        end
+    end
+
+    i1 = clamp(unsafe_trunc(Int, fi1 + T(0.5)), 1, n1)
+    i2 = clamp(unsafe_trunc(Int, fi2 + T(0.5)), 1, n2)
+    i3 = clamp(unsafe_trunc(Int, fi3 + T(0.5)), 1, n3)
+    it = clamp(unsafe_trunc(Int, fit), 1, nt)
+    wt = fit - T(it)
+    jt = min(it + 1, nt)
+    return (one(T) - wt) * data[i1, i2, i3, it] + wt * data[i1, i2, i3, jt]
 end
 
 """

--- a/src/load.jl
+++ b/src/load.jl
@@ -37,7 +37,7 @@ Subtypes with per-variable files should override this.
 """
 relpath(fs::FileSet, t::DateTime, ::Nothing) = relpath(fs, t)
 
-struct FileSetWithRegridder{FS,RF}
+struct FileSetWithRegridder{FS, RF}
     fs::FS
     regridder::RF
 end
@@ -71,6 +71,7 @@ Throws an error listing any missing methods. This is an opt-in check
 intended for use when implementing a new `FileSet` subtype.
 
 # Example
+
 ```julia
 struct MyFileSet <: EarthSciData.FileSet ... end
 # After defining all methods:
@@ -83,7 +84,7 @@ function verify_fileset_interface(::Type{T}) where {T <: FileSet}
         (loadmetadata, Tuple{T, String}, "loadmetadata(::$T, varname::String)"),
         (loadslice!, Tuple{AbstractArray, T, DateTime, String},
             "loadslice!(cache, ::$T, ::DateTime, varname)"),
-        (varnames, Tuple{T}, "varnames(::$T)"),
+        (varnames, Tuple{T}, "varnames(::$T)")
     ]
     missing_methods = String[]
     # relpath must have either a 2-arg or 3-arg method.
@@ -110,7 +111,9 @@ $(SIGNATURES)
 Return the URL for the file for the given `DateTime`.
 An optional `varname` can be provided for datasets with per-variable files.
 """
-url(fs::FileSet, t::DateTime, varname=nothing) = join([mirror(fs), relpath(fs, t, varname)], "/")
+function url(fs::FileSet, t::DateTime, varname = nothing)
+    join([mirror(fs), relpath(fs, t, varname)], "/")
+end
 
 """
 $(SIGNATURES)
@@ -118,7 +121,7 @@ $(SIGNATURES)
 Return the local path for the file for the given `DateTime`.
 An optional `varname` can be provided for datasets with per-variable files.
 """
-function localpath(fs::FileSet, t::DateTime, varname=nothing)
+function localpath(fs::FileSet, t::DateTime, varname = nothing)
     file = relpath(fs, t, varname)
     file = replace(file, ':' => '_')
     joinpath(download_cache(), replace(mirror(fs), "://" => "_"), file)
@@ -127,7 +130,7 @@ end
 """
 Download a file with a progress bar, deleting the partial file on error.
 """
-function _download_with_progress(download_url::AbstractString, path::AbstractString; timeout::Real=300)
+function _download_with_progress(download_url::AbstractString, path::AbstractString; timeout::Real = 300)
     try
         prog = Progress(100; desc = "Downloading $(basename(download_url)):", dt = 0.1)
         Downloads.download(download_url, path,
@@ -151,7 +154,7 @@ $(SIGNATURES)
 Check if the specified file exists locally. If not, download it.
 An optional `varname` can be provided for datasets with per-variable files.
 """
-function maybedownload(fs::FileSet, t::DateTime, varname=nothing)
+function maybedownload(fs::FileSet, t::DateTime, varname = nothing)
     p = localpath(fs, t, varname)
     if isfile(p)
         return p
@@ -304,7 +307,9 @@ mutable struct DataSetInterpolator{To, N, N2, FT, DomT, ET, FSRG}
             stream = true, extrapolate_type = Flat()) where {To <: Real}
         metadata = loadmetadata(fs, varname)
         model_grid = _compute_grid(domain, metadata.staggering)
-        regrid_f = (dst::AbstractArray, src::AbstractArray; extrapolate_type = extrapolate_type) -> begin
+        regrid_f = (dst::AbstractArray,
+            src::AbstractArray;
+            extrapolate_type = extrapolate_type) -> begin
             interpolate_from!(dst, src, metadata, model_grid, domain;
                 extrapolate_type = extrapolate_type)
         end
@@ -350,7 +355,7 @@ mutable struct DataSetInterpolator{To, N, N2, FT, DomT, ET, FSRG}
             metadata,
             domain,
             extrapolate_type,
-            ReentrantLock(),
+            ReentrantLock()
         )
         itp
     end
@@ -546,7 +551,7 @@ function update!(itp::DataSetInterpolator, t::DateTime)
             load_data_for_time!(itp, times[idx]) # Load data if not already loaded.
         end
         # Regrid results into the data buffer.
-        itp.fs.regridder(d, tc.load_cache; extrapolate_type=itp.extrapolate_type)
+        itp.fs.regridder(d, tc.load_cache; extrapolate_type = itp.extrapolate_type)
         # Start loading the next time point asynchronously.
         tc.loadtask = Threads.@spawn load_data_for_time!(
             itp, nexttimepoint(itp, times[idx]))
@@ -615,7 +620,9 @@ function interp_unsafe(
     grid_ranges = _model_grid(itp)
     # Compute fractional 1-based indices
     fit = one(T1) + T1((t_unix - t_start) / t_step)
-    fis = ntuple(i -> one(T1) + T1((locs[i] - first(grid_ranges[i])) / step(grid_ranges[i])), Val(N2))
+    fis = ntuple(
+        i -> one(T1) +
+             T1((locs[i] - first(grid_ranges[i])) / step(grid_ranges[i])), Val(N2))
     extrap = itp.extrapolate_type isa Real ? zero(T1) : one(T1)
     interp_unsafe(tc.data_buffer, fit, fis..., extrap)
 end
@@ -643,7 +650,6 @@ function interp!(itp::DataSetInterpolator, t::Real, locs::Vararg{T, N})::T where
     lazyload!(itp, Dates.unix2datetime(t))
     interp_unsafe(itp, t, locs...)
 end
-
 
 """
 Return the time grid parameters `(t_start, t_step)` from the current cache times
@@ -859,4 +865,3 @@ function _match_domain_coords(dims, pvdict, pvs)
     end
     return coords
 end
-

--- a/src/load.jl
+++ b/src/load.jl
@@ -694,12 +694,23 @@ end
 # computed as: fi = 1 + (coord - grid_start) / grid_step
 # --------------------------------------------------------------------------
 
+# A `fit` (fractional time index) outside `[1, nt]` means the discrete
+# update event did not refresh the cache to cover `integrator.t` — this
+# indicates a bug in `build_interp_event`'s tstop computation, not a user
+# error.  We surface it as an assertion via `@boundscheck` so callers can
+# elide the check with `@inbounds` in performance-critical code, and the
+# `@noinline` keeps the throw path off the hot path.
+@noinline _throw_fit_oor(fit, nt) = throw(ArgumentError(
+    "Interpolation time index $fit outside loaded cache range [1, $nt]; " *
+    "the discrete update event did not refresh the cache for the current integrator time."))
+
 """
 Multilinear interpolation on a 2D array (1 spatial dim + time).
 `fit` and `fi1` are fractional 1-based indices.
 """
 function interp_unsafe(data::AbstractArray{T, 2}, fit, fi1, extrap) where {T}
     n1, nt = size(data)
+    @boundscheck (fit < one(T) || fit > T(nt)) && _throw_fit_oor(fit, nt)
 
     # Extrapolation check
     if extrap < one(T)
@@ -736,6 +747,7 @@ Multilinear interpolation on a 3D array (2 spatial dims + time).
 """
 function interp_unsafe(data::AbstractArray{T, 3}, fit, fi1, fi2, extrap) where {T}
     n1, n2, nt = size(data)
+    @boundscheck (fit < one(T) || fit > T(nt)) && _throw_fit_oor(fit, nt)
 
     # Extrapolation check
     if extrap < one(T)
@@ -781,6 +793,7 @@ Multilinear interpolation on a 4D array (3 spatial dims + time).
 """
 function interp_unsafe(data::AbstractArray{T, 4}, fit, fi1, fi2, fi3, extrap) where {T}
     n1, n2, n3, nt = size(data)
+    @boundscheck (fit < one(T) || fit > T(nt)) && _throw_fit_oor(fit, nt)
 
     # Extrapolation check
     if extrap < one(T)

--- a/src/load.jl
+++ b/src/load.jl
@@ -1,4 +1,4 @@
-export interp, interp!, GridSpec
+export interp_unsafe, interp!, GridSpec
 
 const _LONLAT_SR = "+proj=longlat +datum=WGS84 +no_defs"
 
@@ -260,16 +260,12 @@ Cache for time-varying interpolation state within a `DataSetInterpolator`.
 
 $(FIELDS)
 """
-mutable struct TemporalCache{To, N, N2, ITPT}
-    "The actual data array, with the last dimension being time."
-    data::Array{To, N}
-    "Buffer used for interpolation."
-    interp_cache::Array{To, N}
-    "Buffer that data is read into from file (separate from `data` for async loading)."
+mutable struct TemporalCache{To, N, N2}
+    "Internal buffer holding loaded/regridded data (spatial dims + time). After loading, this is copied to the discrete parameter."
+    data_buffer::Array{To, N}
+    "Buffer that data is read into from file (separate from `data_buffer` for async loading)."
     load_cache::Array{To, N2}
-    "The interpolation object."
-    itp::ITPT
-    "Timestamps corresponding to each time index in `data`."
+    "Timestamps corresponding to each time index in `data_buffer`."
     times::Vector{DateTime}
     "The current time that the interpolator has been loaded for."
     currenttime::DateTime
@@ -294,10 +290,10 @@ data records for the times immediately before and after the current time step.
 the interpolator. `spatial_ref` is the spatial reference system that the simulation will be using.
 `stream` specifies whether the data should be streamed in as needed or loaded all at once.
 """
-mutable struct DataSetInterpolator{To, N, N2, FT, ITPT, DomT, ET, FSRG}
+mutable struct DataSetInterpolator{To, N, N2, FT, DomT, ET, FSRG}
     fs::FSRG
     varname::String
-    cache::TemporalCache{To, N, N2, ITPT}
+    cache::TemporalCache{To, N, N2}
     metadata::MetaData
     domain::DomT
     extrapolate_type::ET
@@ -334,29 +330,20 @@ mutable struct DataSetInterpolator{To, N, N2, FT, ITPT, DomT, ET, FSRG}
         end
 
         load_cache = zeros(To, repeat([1], length(metadata.varsize))...)
-        data = zeros(To, repeat([2], length(metadata.varsize))..., cache_size) # Add a dimension for time.
-        interp_cache = similar(data)
-        N = ndims(data)
+        data_buffer = zeros(To, repeat([2], length(metadata.varsize))..., cache_size) # Add a dimension for time.
+        N = ndims(data_buffer)
         N2 = N - 1
         times = [DateTime(0, 1, 1) + Hour(i) for i in 1:cache_size]
-        _,
-        itp2 = create_interpolator!(
-            interp_cache,
-            data,
-            repeat([0:0.1:0.1], length(metadata.varsize)),
-            times
-        )
-        ITPT = typeof(itp2)
 
         coord_trns = coord_trans(metadata, domain)
         FT = typeof(coord_trns)
 
         td = Threads.@spawn (() -> DateTime(0, 1, 10))() # Placeholder for async loading task.
-        tc = TemporalCache{To, N, N2, ITPT}(
-            data, interp_cache, load_cache, itp2, times,
+        tc = TemporalCache{To, N, N2}(
+            data_buffer, load_cache, times,
             DateTime(1, 1, 1), td, false
         )
-        itp = new{To, N, N2, FT, ITPT, typeof(domain), typeof(extrapolate_type), typeof(fs)}(
+        itp = new{To, N, N2, FT, typeof(domain), typeof(extrapolate_type), typeof(fs)}(
             fs,
             String(varname),
             tc,
@@ -432,34 +419,8 @@ function _pad_singletons(data, coords)
     return padded, padded_coords
 end
 
-"""
-Create a new interpolator, overwriting `interp_cache`.
-"""
-function create_interpolator!(interp_cache, data, coords, times)
-    grid = tuple((knots2range(Float64.(c)) for c in coords)..., knots2range(datetime2unix.(times)))
-    padded, pad_grid = _pad_singletons(data, grid)
-    if size(interp_cache) != size(padded)
-        interp_cache = similar(padded)
-    end
-    copyto!(interp_cache, padded)
-    itp = interpolate!(interp_cache, BSpline(Linear()))
-    itp = scale(itp, pad_grid...)
-    return pad_grid, itp
-end
-
-function update_interpolator!(itp::DataSetInterpolator{To}) where {To}
-    tc = itp.cache
-    if size(tc.interp_cache) != size(tc.data)
-        tc.interp_cache = similar(tc.data)
-    end
-    coords = _model_grid(itp)
-    grid, itp2 = create_interpolator!(tc.interp_cache, tc.data, coords, tc.times)
-    # Grid may have been padded along singleton dimensions, so compare with
-    # the padded data size rather than tc.data.
-    padded_data, _ = _pad_singletons(tc.data, grid)
-    @assert all([length(g) for g in grid] .== size(padded_data)) "invalid data size: $([length(g) for g in grid]) != $(size(padded_data))"
-    tc.itp = itp2
-end
+# create_interpolator! and update_interpolator! have been removed.
+# Interpolation is now done by the array-based interp_unsafe functions.
 
 """
 Return the next interpolation time point for this interpolator.
@@ -539,7 +500,7 @@ function initialize!(itp::DataSetInterpolator, t::DateTime)
     tc = itp.cache
     tc.load_cache = zeros(eltype(tc.load_cache), itp.metadata.varsize...)
     grid_size = length.(_model_grid(itp))
-    tc.data = zeros(eltype(tc.data), grid_size..., size(tc.data, length(size(tc.data)))) # Add a dimension for time.
+    tc.data_buffer = zeros(eltype(tc.data_buffer), grid_size..., size(tc.data_buffer, ndims(tc.data_buffer))) # Add a dimension for time.
     tc.initialized = true
 end
 
@@ -562,15 +523,15 @@ function update!(itp::DataSetInterpolator, t::DateTime)
     idxs_not_in_times = setdiff(eachindex(times), idxs_in_times)
 
     # Move data we already have to where it should be.
-    N = ndims(tc.data)
+    N = ndims(tc.data_buffer)
     if all(idxs_in_cache .> idxs_in_times) && all(issorted.((idxs_in_cache, idxs_in_times)))
         for (new, old) in zip(idxs_in_times, idxs_in_cache)
-            selectdim(tc.data, N, new) .= selectdim(tc.data, N, old)
+            selectdim(tc.data_buffer, N, new) .= selectdim(tc.data_buffer, N, old)
         end
     elseif all(idxs_in_cache .< idxs_in_times) &&
            all(issorted.((idxs_in_cache, idxs_in_times)))
         for (new, old) in zip(reverse(idxs_in_times), reverse(idxs_in_cache))
-            selectdim(tc.data, N, new) .= selectdim(tc.data, N, old)
+            selectdim(tc.data_buffer, N, new) .= selectdim(tc.data_buffer, N, old)
         end
     elseif !all(idxs_in_cache .== idxs_in_times)
         error(
@@ -580,11 +541,11 @@ function update!(itp::DataSetInterpolator, t::DateTime)
 
     # Load the additional times we need
     for idx in idxs_not_in_times
-        d = selectdim(tc.data, N, idx)
+        d = selectdim(tc.data_buffer, N, idx)
         if fetch(tc.loadtask) != times[idx] # Check if correct time is already loaded.
             load_data_for_time!(itp, times[idx]) # Load data if not already loaded.
         end
-        # Regrid results into the data array.
+        # Regrid results into the data buffer.
         itp.fs.regridder(d, tc.load_cache; extrapolate_type=itp.extrapolate_type)
         # Start loading the next time point asynchronously.
         tc.loadtask = Threads.@spawn load_data_for_time!(
@@ -593,7 +554,6 @@ function update!(itp::DataSetInterpolator, t::DateTime)
     tc.times = times
     tc.currenttime = t
     @assert issorted(tc.times) "Interpolator times are in wrong order"
-    update_interpolator!(itp)
 end
 
 function lazyload!(itp::DataSetInterpolator, t::DateTime)
@@ -641,73 +601,224 @@ description(itp::DataSetInterpolator) = itp.metadata.description
 """
 $(SIGNATURES)
 
-Return the value of the given variable from the given dataset at the given time and location.
-"""
-function interp(
-        itp::DataSetInterpolator{T, N, N2},
-        t::DateTime,
-        locs::Vararg{T, N2}
-)::T where {T, N, N2}
-    lazyload!(itp, t)
-    interp_unsafe(itp, t, locs...)
-end
-
-"""
 Interpolate without checking if the data has been correctly loaded for the given time.
+This convenience method on `DataSetInterpolator` delegates to the array-based `interp_unsafe`.
 """
-@generated function interp_unsafe(
+function interp_unsafe(
         itp::DataSetInterpolator{T1, N, N2},
         t::DateTime,
         locs::Vararg{T2, N2}
 ) where {T1, T2, N, N2}
-    if N2 == N - 1 # Number of locs has to be one less than the number of data dimensions so we can add the time in.
-        quote
-            try
-                itp.cache.itp(locs..., datetime2unix(t))
-            catch err
-                # FIXME(CT): This is needed because ModelingToolkit sometimes
-                # calls the interpolator for the beginning of the simulation time period,
-                # and we don't have a way to update for that proactively.
-                @warn "Interpolation for $(itp.varname) failed at t=$(t), locs=$(locs); trying to update interpolator."
-                lazyload!(itp, t)
-                itp.cache.itp(locs..., datetime2unix(t))
-            end
-        end
-    else
-        throw(ArgumentError("N2 must be equal to N-1"))
-    end
+    tc = itp.cache
+    t_unix = datetime2unix(t)
+    t_start, t_step = get_time_grid_params(itp)
+    grid_ranges = _model_grid(itp)
+    # Compute fractional 1-based indices
+    fit = one(T1) + T1((t_unix - t_start) / t_step)
+    fis = ntuple(i -> one(T1) + T1((locs[i] - first(grid_ranges[i])) / step(grid_ranges[i])), Val(N2))
+    extrap = itp.extrapolate_type isa Real ? zero(T1) : one(T1)
+    interp_unsafe(tc.data_buffer, fit, fis..., extrap)
 end
 
 """
 Interpolation with a unix timestamp.
 """
-function interp(itp::DataSetInterpolator, t::Real, locs::Vararg{T, N})::T where {T, N}
-    interp(itp, Dates.unix2datetime(t), locs...)
-end
 function interp_unsafe(
         itp::DataSetInterpolator, t::Real, locs::Vararg{T, N})::T where {T, N}
     interp_unsafe(itp, Dates.unix2datetime(t), locs...)
 end
 
-# Deprecated: use `interp` instead of `interp!`.
+# Deprecated: use `interp_unsafe` directly.
 function interp!(
         itp::DataSetInterpolator{T, N, N2},
         t::DateTime,
         locs::Vararg{T, N2}
 )::T where {T, N, N2}
-    Base.depwarn("`interp!` is deprecated, use `interp` instead.", :interp!)
-    interp(itp, t, locs...)
+    Base.depwarn("`interp!` is deprecated, use `interp_unsafe` instead.", :interp!)
+    lazyload!(itp, t)
+    interp_unsafe(itp, t, locs...)
 end
 function interp!(itp::DataSetInterpolator, t::Real, locs::Vararg{T, N})::T where {T, N}
-    Base.depwarn("`interp!` is deprecated, use `interp` instead.", :interp!)
-    interp(itp, t, locs...)
-end
-# Generic fallback for unit validation (DynamicQuantities.Quantity arguments).
-function interp!(args...)
-    Base.depwarn("`interp!` is deprecated, use `interp` instead.", :interp!)
-    interp(args...)
+    Base.depwarn("`interp!` is deprecated, use `interp_unsafe` instead.", :interp!)
+    lazyload!(itp, Dates.unix2datetime(t))
+    interp_unsafe(itp, t, locs...)
 end
 
+
+"""
+Return the time grid parameters `(t_start, t_step)` from the current cache times
+as Unix timestamps.
+"""
+function get_time_grid_params(itp::DataSetInterpolator)
+    tc = itp.cache
+    t_start = datetime2unix(tc.times[1])
+    if length(tc.times) > 1
+        t_end = datetime2unix(tc.times[end])
+        t_step = (t_end - t_start) / (length(tc.times) - 1)
+    else
+        t_step = one(t_start)
+    end
+    return (t_start, t_step)
+end
+
+"""
+Return the spatial grid parameters as a flat tuple `(s1_start, s1_step, s2_start, s2_step, ...)`.
+"""
+function get_spatial_grid_params(itp::DataSetInterpolator)
+    ranges = _model_grid(itp)
+    params = Float64[]
+    for r in ranges
+        push!(params, first(r))
+        push!(params, step(r))
+    end
+    return Tuple(params)
+end
+
+# --------------------------------------------------------------------------
+# Array-based multilinear interpolation functions.
+# These operate on plain arrays + fractional 1-based indices and are
+# GPU-compatible (pure arithmetic + array indexing, zero allocations).
+#
+# The `extrap` parameter controls extrapolation:
+#   extrap >= 1.0 → Flat (clamp to boundary values)
+#   extrap < 1.0  → return zero for out-of-bounds
+#
+# The data array has spatial dimensions first, time dimension last.
+# All index arguments (fit, fi1, ...) are fractional 1-based indices,
+# computed as: fi = 1 + (coord - grid_start) / grid_step
+# --------------------------------------------------------------------------
+
+"""
+Multilinear interpolation on a 2D array (1 spatial dim + time).
+`fit` and `fi1` are fractional 1-based indices.
+"""
+function interp_unsafe(data::AbstractArray{T, 2}, fit, fi1, extrap) where {T}
+    n1, nt = size(data)
+
+    # Extrapolation check
+    if extrap < one(T)
+        if fi1 < one(T) || fi1 > T(n1) || fit < one(T) || fit > T(nt)
+            return zero(T)
+        end
+    end
+
+    # Clamp to valid range
+    fi1 = clamp(fi1, one(T), T(n1))
+    fit = clamp(fit, one(T), T(nt))
+
+    # Floor indices and weights
+    i1 = clamp(unsafe_trunc(Int, fi1), 1, n1)
+    it = clamp(unsafe_trunc(Int, fit), 1, nt)
+    w1 = fi1 - T(i1)
+    wt = fit - T(it)
+
+    # Upper indices (clamped)
+    j1 = min(i1 + 1, n1)
+    jt = min(it + 1, nt)
+
+    # Bilinear interpolation (2D: 4 corners)
+    result = (one(T) - w1) * (one(T) - wt) * data[i1, it] +
+             w1 * (one(T) - wt) * data[j1, it] +
+             (one(T) - w1) * wt * data[i1, jt] +
+             w1 * wt * data[j1, jt]
+    return result
+end
+
+"""
+Multilinear interpolation on a 3D array (2 spatial dims + time).
+`fit`, `fi1`, `fi2` are fractional 1-based indices.
+"""
+function interp_unsafe(data::AbstractArray{T, 3}, fit, fi1, fi2, extrap) where {T}
+    n1, n2, nt = size(data)
+
+    # Extrapolation check
+    if extrap < one(T)
+        if fi1 < one(T) || fi1 > T(n1) || fi2 < one(T) || fi2 > T(n2) ||
+           fit < one(T) || fit > T(nt)
+            return zero(T)
+        end
+    end
+
+    # Clamp to valid range
+    fi1 = clamp(fi1, one(T), T(n1))
+    fi2 = clamp(fi2, one(T), T(n2))
+    fit = clamp(fit, one(T), T(nt))
+
+    # Floor indices and weights
+    i1 = clamp(unsafe_trunc(Int, fi1), 1, n1)
+    i2 = clamp(unsafe_trunc(Int, fi2), 1, n2)
+    it = clamp(unsafe_trunc(Int, fit), 1, nt)
+    w1 = fi1 - T(i1)
+    w2 = fi2 - T(i2)
+    wt = fit - T(it)
+
+    # Upper indices (clamped)
+    j1 = min(i1 + 1, n1)
+    j2 = min(i2 + 1, n2)
+    jt = min(it + 1, nt)
+
+    # Trilinear interpolation (3D: 8 corners)
+    result = zero(T)
+    for (ii1, ww1) in ((i1, one(T) - w1), (j1, w1))
+        for (ii2, ww2) in ((i2, one(T) - w2), (j2, w2))
+            for (iit, wwt) in ((it, one(T) - wt), (jt, wt))
+                result += ww1 * ww2 * wwt * data[ii1, ii2, iit]
+            end
+        end
+    end
+    return result
+end
+
+"""
+Multilinear interpolation on a 4D array (3 spatial dims + time).
+`fit`, `fi1`, `fi2`, `fi3` are fractional 1-based indices.
+"""
+function interp_unsafe(data::AbstractArray{T, 4}, fit, fi1, fi2, fi3, extrap) where {T}
+    n1, n2, n3, nt = size(data)
+
+    # Extrapolation check
+    if extrap < one(T)
+        if fi1 < one(T) || fi1 > T(n1) || fi2 < one(T) || fi2 > T(n2) ||
+           fi3 < one(T) || fi3 > T(n3) || fit < one(T) || fit > T(nt)
+            return zero(T)
+        end
+    end
+
+    # Clamp to valid range
+    fi1 = clamp(fi1, one(T), T(n1))
+    fi2 = clamp(fi2, one(T), T(n2))
+    fi3 = clamp(fi3, one(T), T(n3))
+    fit = clamp(fit, one(T), T(nt))
+
+    # Floor indices and weights
+    i1 = clamp(unsafe_trunc(Int, fi1), 1, n1)
+    i2 = clamp(unsafe_trunc(Int, fi2), 1, n2)
+    i3 = clamp(unsafe_trunc(Int, fi3), 1, n3)
+    it = clamp(unsafe_trunc(Int, fit), 1, nt)
+    w1 = fi1 - T(i1)
+    w2 = fi2 - T(i2)
+    w3 = fi3 - T(i3)
+    wt = fit - T(it)
+
+    # Upper indices (clamped)
+    j1 = min(i1 + 1, n1)
+    j2 = min(i2 + 1, n2)
+    j3 = min(i3 + 1, n3)
+    jt = min(it + 1, nt)
+
+    # Quadrilinear interpolation (4D: 16 corners)
+    result = zero(T)
+    for (ii1, ww1) in ((i1, one(T) - w1), (j1, w1))
+        for (ii2, ww2) in ((i2, one(T) - w2), (j2, w2))
+            for (ii3, ww3) in ((i3, one(T) - w3), (j3, w3))
+                for (iit, wwt) in ((it, one(T) - wt), (jt, wt))
+                    result += ww1 * ww2 * ww3 * wwt * data[ii1, ii2, ii3, iit]
+                end
+            end
+        end
+    end
+    return result
+end
 
 """
 Close resources associated with a FileSet. Default is a no-op.

--- a/src/load.jl
+++ b/src/load.jl
@@ -700,10 +700,13 @@ end
 # error.  We surface it as an assertion via `@boundscheck` so callers can
 # elide the check with `@inbounds` in performance-critical code, and the
 # `@noinline` keeps the throw path off the hot path.
-@noinline _throw_fit_oor(fit,
-    nt) = throw(ArgumentError(
-    "Interpolation time index $fit outside loaded cache range [1, $nt]; " *
-    "the discrete update event did not refresh the cache for the current integrator time."))
+#
+# The error has no interpolated arguments so the compiler can lift the
+# error object to a constant — important on GPUs where constructing an
+# Exception with runtime values allocates and may abort kernel compilation.
+@noinline _throw_fit_oor() = error(
+    "interp_unsafe: time index outside loaded cache range; the discrete " *
+    "update event did not refresh the cache for the current integrator time.")
 
 """
 Multilinear interpolation on a 2D array (1 spatial dim + time).
@@ -711,7 +714,7 @@ Multilinear interpolation on a 2D array (1 spatial dim + time).
 """
 function interp_unsafe(data::AbstractArray{T, 2}, fit, fi1, extrap) where {T}
     n1, nt = size(data)
-    @boundscheck (fit < one(T) || fit > T(nt)) && _throw_fit_oor(fit, nt)
+    @boundscheck (fit < one(T) || fit > T(nt)) && _throw_fit_oor()
 
     # Extrapolation check
     if extrap < one(T)
@@ -748,7 +751,7 @@ Multilinear interpolation on a 3D array (2 spatial dims + time).
 """
 function interp_unsafe(data::AbstractArray{T, 3}, fit, fi1, fi2, extrap) where {T}
     n1, n2, nt = size(data)
-    @boundscheck (fit < one(T) || fit > T(nt)) && _throw_fit_oor(fit, nt)
+    @boundscheck (fit < one(T) || fit > T(nt)) && _throw_fit_oor()
 
     # Extrapolation check
     if extrap < one(T)
@@ -794,7 +797,7 @@ Multilinear interpolation on a 4D array (3 spatial dims + time).
 """
 function interp_unsafe(data::AbstractArray{T, 4}, fit, fi1, fi2, fi3, extrap) where {T}
     n1, n2, n3, nt = size(data)
-    @boundscheck (fit < one(T) || fit > T(nt)) && _throw_fit_oor(fit, nt)
+    @boundscheck (fit < one(T) || fit > T(nt)) && _throw_fit_oor()
 
     # Extrapolation check
     if extrap < one(T)
@@ -856,7 +859,7 @@ integer-valued at a grid point.
 """
 function interp_time_only(data::AbstractArray{T, 2}, fit, fi1, extrap) where {T}
     n1, nt = size(data)
-    @boundscheck (fit < one(T) || fit > T(nt)) && _throw_fit_oor(fit, nt)
+    @boundscheck (fit < one(T) || fit > T(nt)) && _throw_fit_oor()
 
     # Extrapolation check (zero outside range if extrap < 1)
     if extrap < one(T)
@@ -877,7 +880,7 @@ Nearest-neighbour spatial + linear time interpolation on a 3D array.
 """
 function interp_time_only(data::AbstractArray{T, 3}, fit, fi1, fi2, extrap) where {T}
     n1, n2, nt = size(data)
-    @boundscheck (fit < one(T) || fit > T(nt)) && _throw_fit_oor(fit, nt)
+    @boundscheck (fit < one(T) || fit > T(nt)) && _throw_fit_oor()
 
     if extrap < one(T)
         if fi1 < one(T) || fi1 > T(n1) || fi2 < one(T) || fi2 > T(n2)
@@ -899,7 +902,7 @@ Nearest-neighbour spatial + linear time interpolation on a 4D array.
 function interp_time_only(
         data::AbstractArray{T, 4}, fit, fi1, fi2, fi3, extrap) where {T}
     n1, n2, n3, nt = size(data)
-    @boundscheck (fit < one(T) || fit > T(nt)) && _throw_fit_oor(fit, nt)
+    @boundscheck (fit < one(T) || fit > T(nt)) && _throw_fit_oor()
 
     if extrap < one(T)
         if fi1 < one(T) || fi1 > T(n1) || fi2 < one(T) || fi2 > T(n2) ||

--- a/src/mtk_integration.jl
+++ b/src/mtk_integration.jl
@@ -61,20 +61,6 @@ for n_args in 4:6
         $(fill(:(::Symbolics.SymbolicUtils.ShapeT), n_args)...)) = _scalar_shape
 end
 
-# Fix SymbolicUtils bug: promote_shape for ifelse returns `true` (Bool) instead of the
-# shape when branches match, because `sht == shf || error(...)` returns `true`.
-# This causes parse_shape(::Bool) errors when maketerm rebuilds ifelse during substitute.
-# Must be done in __init__ because method overwriting is not allowed during precompilation.
-function _fix_ifelse_promote_shape()
-    @eval Symbolics.SymbolicUtils function promote_shape(::typeof(ifelse),
-            shc::ShapeT, sht::ShapeT, shf::ShapeT)
-        @nospecialize shc sht shf
-        is_array_shape(shc) && error("Condition of `ifelse` cannot be an array.")
-        sht == shf || error("Both branches of `ifelse` must have the same shape.")
-        return sht
-    end
-end
-
 function _make_array_discrete(name::Symbol, init_data, ndims::Int, desc::String)
     return only(@discretes $name(t)::DataBufferType = Float64.(init_data) [
         description = desc])

--- a/src/mtk_integration.jl
+++ b/src/mtk_integration.jl
@@ -167,9 +167,23 @@ function create_interp_equation(itp::DataSetInterpolator{To}, filename, t, t_ref
         "Interpolation data for $(n)")
 
     # Time grid discretes — scalar defaults work fine in MTK.
+    #
+    # Choose initial defaults such that the computed fractional time index
+    # `fit = 1 + (t_ref + t - p_tstart) / p_tstep` lands at `1.0` when
+    # `t = 0`.  This matters because ODE solvers evaluate the RHS *once*
+    # during `init(prob, alg)` BEFORE firing the discrete callback's
+    # `initialize` affect (the Tsit5 FSAL call in `Tsit5Cache.initialize!`
+    # runs first).  At that point the data buffer is still zeros, but we
+    # need `fit` to be in `[1, nt]` so `@boundscheck` doesn't fire on an
+    # uninitialized interpolator.  Setting `p_tstart = t_ref` yields
+    # `fit = 1` and `interp_unsafe` returns zero from the zero buffer —
+    # same behaviour as before the bounds check was added.  The callback's
+    # initialize affect subsequently overwrites both defaults with real
+    # values from the loaded cache.
     n_tstart = Symbol(n, :_tstart)
     n_tstep = Symbol(n, :_tstep)
-    ts_default, tstep_default = get_time_grid_params(itp)
+    ts_default = EarthSciMLBase.get_tref(itp.domain)
+    tstep_default = 1.0
     p_tstart = only(@discretes $n_tstart(t) = ts_default [
         unit = u"s", description = "Time grid start for $(n)"])
     p_tstep = only(@discretes $n_tstep(t) = tstep_default [

--- a/src/mtk_integration.jl
+++ b/src/mtk_integration.jl
@@ -158,12 +158,24 @@ function create_interp_equation(itp::DataSetInterpolator{To}, filename, t, t_ref
     # `similar(domain.u_proto, ...)` so the buffer inherits the array backend
     # of the state vector (plain `Array` on CPU, `CuArray`/`ROCArray`/etc. on
     # device). Element type comes from the interpolator's `To` parameter,
-    # which is derived from `eltype(domaininfo)`. Initial value is zeros; the
-    # discrete update event populates the buffer at solve time.
+    # which is derived from `eltype(domaininfo)`.
+    #
+    # *Size*: use a minimal sentinel array at construction time rather than
+    # the full model grid.  At production domain sizes the full grid can be
+    # hundreds of MB per variable; pre-allocating one for every symbolic
+    # `create_interp_equation` would blow up the build-time memory budget
+    # (GitHub Actions runners have 7 GB RAM, a multi-loader simulation has
+    # 200+ variables).  The discrete update event (`build_interp_event`)
+    # replaces the sentinel with a full-sized array only for the variables
+    # whose data is actually referenced in the compiled RHS, matching the
+    # pre-refactor behaviour of growing on first event fire.  The number of
+    # dimensions still has to match the runtime `interp_unsafe` dispatch, so
+    # we keep `ndims` intact and only collapse each spatial/time axis to 2.
     n_data = Symbol(n, :_data)
-    init_data = similar(itp.domain.u_proto, To, data_dims...)
+    sentinel_dims = ntuple(_ -> 2, length(data_dims))
+    init_data = similar(itp.domain.u_proto, To, sentinel_dims...)
     fill!(init_data, zero(To))
-    p_data = _make_array_discrete(n_data, init_data, length(data_dims),
+    p_data = _make_array_discrete(n_data, init_data, length(sentinel_dims),
         "Interpolation data for $(n)")
 
     # Time grid discretes — scalar defaults work fine in MTK.

--- a/src/mtk_integration.jl
+++ b/src/mtk_integration.jl
@@ -14,17 +14,24 @@ Base.convert(::Type{DataBufferType}, x::DataBufferType) = x
 Base.convert(::Type{DataBufferType}, x) = DataBufferType(x)
 Base.copy(x::DataBufferType) = DataBufferType(copy(x.data))
 
-# Dummy function for unit validation. ModelingToolkit calls the function with
+# Dummy functions for unit validation. ModelingToolkit calls the function with
 # a DynamicQuantities.Quantity or an integer to get information about the type
 # and units of the output. The array-based interp_unsafe is unitless, so we
 # return a dimensionless value (units are applied via a separate @constants multiplier).
 function interp_unsafe(data::Union{DynamicQuantities.AbstractQuantity, Real}, fit, args...)
     one(Float64)
 end
+function interp_time_only(
+        data::Union{DynamicQuantities.AbstractQuantity, Real}, fit, args...)
+    one(Float64)
+end
 
-# Runtime unwrap: when MTK calls interp_unsafe with a DataBufferType wrapper,
-# forward to the actual array-based implementation.
+# Runtime unwrap: when MTK calls interp_unsafe/interp_time_only with a
+# DataBufferType wrapper, forward to the actual array-based implementation.
 interp_unsafe(data::DataBufferType, fit, args...) = interp_unsafe(data.data, fit, args...)
+function interp_time_only(data::DataBufferType, fit, args...)
+    interp_time_only(data.data, fit, args...)
+end
 
 # Symbolic tracing for array-based interp_unsafe.
 # Arguments are: data, fit (fractional time index), fi1..fiN (fractional spatial indices), extrap.
@@ -37,27 +44,37 @@ interp_unsafe(data::DataBufferType, fit, args...) = interp_unsafe(data.data, fit
 # 1 spatial dim + time (2D array): data, fit, fi1, extrap = 4 args
 @register_symbolic interp_unsafe(data::DataBufferType, fit, fi1, extrap) false
 
-# Tell SymbolicUtils that interp_unsafe always returns a Real scalar.
+# Same registrations for interp_time_only (spatial nearest, time linear).
+@register_symbolic interp_time_only(data::DataBufferType, fit, fi1, fi2, fi3, extrap) false
+@register_symbolic interp_time_only(data::DataBufferType, fit, fi1, fi2, extrap) false
+@register_symbolic interp_time_only(data::DataBufferType, fit, fi1, extrap) false
+
+# Tell SymbolicUtils that interp_unsafe/interp_time_only always return a Real scalar.
 # promote_symtype: @register_symbolic generates promote_symtype dispatches for the
 # declared argument types, but DataBufferType needs explicit overrides since
 # the fallback may not handle it correctly.
 for n_args in 4:6
     @eval Symbolics.SymbolicUtils.promote_symtype(::typeof(interp_unsafe),
         ::Type{DataBufferType}, $(fill(:(::Type), n_args - 2)...), ::Type) = Real
+    @eval Symbolics.SymbolicUtils.promote_symtype(::typeof(interp_time_only),
+        ::Type{DataBufferType}, $(fill(:(::Type), n_args - 2)...), ::Type) = Real
 end
 
-# Register zero derivatives for interp_unsafe. The data is updated discretely via
-# callbacks (not continuously), so the symbolic derivative is zero for all arguments.
+# Register zero derivatives. The data is updated discretely via callbacks
+# (not continuously), so the symbolic derivative is zero for all arguments.
 # Without this, calculate_tgrad creates unevaluated Differential terms with symtype Any,
 # which causes *(::Type{Any}, ::Type{Real}) errors in the IMEX solver path.
 @register_derivative interp_unsafe(args...) I Symbolics.SConst(zero(Float64))
+@register_derivative interp_time_only(args...) I Symbolics.SConst(zero(Float64))
 
-# Tell SymbolicUtils that interp_unsafe always returns a scalar shape.
+# Tell SymbolicUtils that interp_unsafe/interp_time_only always return a scalar shape.
 # Without this, maketerm's default promote_shape returns Unknown(-1) when rebuilding
 # during substitute, which breaks ifelse shape checks.
 const _scalar_shape = Symbolics.SymbolicUtils.ShapeVecT()
 for n_args in 4:6
     @eval Symbolics.SymbolicUtils.promote_shape(::typeof(interp_unsafe),
+        $(fill(:(::Symbolics.SymbolicUtils.ShapeT), n_args)...)) = _scalar_shape
+    @eval Symbolics.SymbolicUtils.promote_shape(::typeof(interp_time_only),
         $(fill(:(::Symbolics.SymbolicUtils.ShapeT), n_args)...)) = _scalar_shape
 end
 
@@ -74,6 +91,17 @@ Create an equation that interpolates the given dataset at the given time and loc
 `wrapper_f` can specify a function to wrap the interpolated value, for example `eq -> eq / 2`
 to divide the interpolated value by 2.
 
+`spatial_interp` selects the spatial interpolation mode:
+
+  - `:linear` (default) — full multilinear interpolation (2^(1+dim) corners).
+    Safe for arbitrary query points; the classic behavior.
+  - `:nearest` — nearest-neighbour spatial indexing combined with linear time
+    interpolation (2 corners). Used when the caller knows every query is at a
+    grid point that matches the data grid exactly — e.g., a PDE simulation on
+    the same grid the data is regridded to. `interp_unsafe` is replaced with
+    `interp_time_only` at the symbolic level, eliminating the wasted corner
+    loads/multiplies.
+
 Returns `(equation, discretes, constants, interp_info)` where:
 
   - `discretes`: vector of discrete symbolic variables [data, t_start, t_step]
@@ -81,7 +109,11 @@ Returns `(equation, discretes, constants, interp_info)` where:
   - `interp_info`: named tuple with all symbolic pieces needed to build interpolation expressions
 """
 function create_interp_equation(itp::DataSetInterpolator{To}, filename, t, t_ref, coords;
-        wrapper_f = v -> v) where {To}
+        wrapper_f = v -> v, spatial_interp::Symbol = :linear) where {To}
+    spatial_interp in (:linear, :nearest) ||
+        throw(ArgumentError("spatial_interp must be :linear or :nearest, got $spatial_interp"))
+    interp_f = spatial_interp === :nearest ? interp_time_only : interp_unsafe
+
     n = length(filename) > 0 ? Symbol("$(filename)₊$(itp.varname)") :
         Symbol("$(itp.varname)")
 
@@ -145,8 +177,9 @@ function create_interp_equation(itp::DataSetInterpolator{To}, filename, t, t_ref
     fis = [1 + (coords[i] - spatial_consts[2i - 1]) / spatial_consts[2i]
            for i in 1:length(coords)]
 
-    # Build RHS: interp_unsafe(data, fit, fi1, ..., extrap) * unit_scale
-    rhs_interp = interp_unsafe(p_data, fit, fis..., p_extrap) * unit_scale
+    # Build RHS: interp_f(data, fit, fi1, ..., extrap) * unit_scale
+    # where interp_f is either interp_unsafe (linear) or interp_time_only (nearest).
+    rhs_interp = interp_f(p_data, fit, fis..., p_extrap) * unit_scale
 
     # Apply wrapper (e.g., NEI scaling).
     rhs = wrapper_f(rhs_interp)
@@ -180,7 +213,7 @@ function create_interp_equation(itp::DataSetInterpolator{To}, filename, t, t_ref
         spatial_consts = spatial_consts, extrap_const = p_extrap,
         unit_const = unit_scale, itp = itp, var_sym = n,
         data_dims = data_dims, data_eltype = To,
-        const_defaults = const_defaults)
+        const_defaults = const_defaults, spatial_interp = spatial_interp)
 
     return eq, discretes, constants, interp_info
 end
@@ -191,13 +224,16 @@ $(SIGNATURES)
 Build a symbolic interpolation expression for the given `interp_info` at the given
 time expression and coordinate expressions. This is useful when you need to evaluate
 the interpolation at modified coordinates (e.g., `lev + 1` for finite differences).
+Uses the same `spatial_interp` mode that was configured on `interp_info`.
 """
 function build_interp_expr(info, t_expr, coord_exprs)
     fit = 1 + (t_expr - info.tstart_sym) / info.tstep_sym
     n_spatial = length(coord_exprs)
     fis = [1 + (coord_exprs[i] - info.spatial_consts[2i - 1]) / info.spatial_consts[2i]
            for i in 1:n_spatial]
-    interp_unsafe(info.data_sym, fit, fis..., info.extrap_const) * info.unit_const
+    interp_f = get(info, :spatial_interp, :linear) === :nearest ? interp_time_only :
+               interp_unsafe
+    interp_f(info.data_sym, fit, fis..., info.extrap_const) * info.unit_const
 end
 
 # In MTK v11, parameter defaults set via `@parameters x = val` are stored as

--- a/src/mtk_integration.jl
+++ b/src/mtk_integration.jl
@@ -5,13 +5,27 @@
 # Custom symtype for data buffer discretes. Using a non-Real, non-AbstractArray
 # type gives scalar symbolic shape (so canonicalize_eq! works) while routing
 # values to MTK's nonnumeric parameter buffer (is_variable_floatingpoint returns false).
-# Concrete wrapper so that MTK's Vector{DataBufferType} buffer can hold array values
-# via convert(DataBufferType, array).
-struct DataBufferType
-    data::Any
+# Parameterized on the underlying array type so that dispatch resolves the
+# concrete element type and backend (CPU `Array` vs. device arrays like
+# `CuArray`). This is load-bearing for GPU execution: `interp_unsafe(data.data,
+# ...)` is only type-stable (and therefore kernel-compilable) when the array
+# type is known at compile time — not when `data.data::Any`.
+struct DataBufferType{A <: AbstractArray}
+    data::A
+end
+# Pass-through constructors for MTK's `narrow_buffer_type`, which broadcasts
+# the target type over each entry of the nonnumeric buffer. When an entry is
+# already wrapped we short-circuit; when given a raw array we wrap it.
+DataBufferType{A}(x::DataBufferType{A}) where {A <: AbstractArray} = x
+function DataBufferType{A}(x::DataBufferType) where {A <: AbstractArray}
+    DataBufferType{A}(convert(A, x.data))
 end
 Base.convert(::Type{DataBufferType}, x::DataBufferType) = x
-Base.convert(::Type{DataBufferType}, x) = DataBufferType(x)
+Base.convert(::Type{DataBufferType}, x::AbstractArray) = DataBufferType(x)
+Base.convert(::Type{DataBufferType{A}}, x::DataBufferType{A}) where {A} = x
+function Base.convert(::Type{DataBufferType{A}}, x::AbstractArray) where {A}
+    DataBufferType{A}(convert(A, x))
+end
 Base.copy(x::DataBufferType) = DataBufferType(copy(x.data))
 
 # Dummy functions for unit validation. ModelingToolkit calls the function with
@@ -52,12 +66,14 @@ end
 # Tell SymbolicUtils that interp_unsafe/interp_time_only always return a Real scalar.
 # promote_symtype: @register_symbolic generates promote_symtype dispatches for the
 # declared argument types, but DataBufferType needs explicit overrides since
-# the fallback may not handle it correctly.
+# the fallback may not handle it correctly. `Type{<:DataBufferType}` matches
+# any concrete parameterization (e.g. `DataBufferType{Array{Float64,4}}`,
+# `DataBufferType{Array{Float32,4}}`, `DataBufferType{CuArray{Float64,4}}`).
 for n_args in 4:6
     @eval Symbolics.SymbolicUtils.promote_symtype(::typeof(interp_unsafe),
-        ::Type{DataBufferType}, $(fill(:(::Type), n_args - 2)...), ::Type) = Real
+        ::Type{<:DataBufferType}, $(fill(:(::Type), n_args - 2)...), ::Type) = Real
     @eval Symbolics.SymbolicUtils.promote_symtype(::typeof(interp_time_only),
-        ::Type{DataBufferType}, $(fill(:(::Type), n_args - 2)...), ::Type) = Real
+        ::Type{<:DataBufferType}, $(fill(:(::Type), n_args - 2)...), ::Type) = Real
 end
 
 # Register zero derivatives. The data is updated discretely via callbacks
@@ -79,8 +95,22 @@ for n_args in 4:6
 end
 
 function _make_array_discrete(name::Symbol, init_data, ndims::Int, desc::String)
-    return only(@discretes $name(t)::DataBufferType = Float64.(init_data) [
-        description = desc])
+    # `init_data` is allocated by the caller via `similar(domain.u_proto, ...)`,
+    # so it already has the correct element type and array backend (CPU vs.
+    # device). Do NOT promote to Float64 here — that would break Float32
+    # simulations and force all data buffers onto the host.
+    #
+    # `@discretes` needs a concrete `DataType` for the `::T` annotation, and
+    # `DataBufferType` as a parameterized struct is a `UnionAll`.  Build the
+    # concrete parameterization `DataBufferType{typeof(init_data)}` at runtime
+    # and feed it into `@discretes` via `@eval` so the macro sees a concrete
+    # type.  This is called a handful of times at model construction — the
+    # `@eval` cost is in the noise compared to `mtkcompile`.
+    BT = DataBufferType{typeof(init_data)}
+    expr = quote
+        @discretes $name(t)::$BT = $init_data [description = $desc]
+    end
+    return only(Core.eval(@__MODULE__, expr))
 end
 
 """
@@ -123,12 +153,16 @@ function create_interp_equation(itp::DataSetInterpolator{To}, filename, t, t_ref
     cache_nt = size(itp.cache.data_buffer, ndims(itp.cache.data_buffer))
     data_dims = (grid_dims..., cache_nt)
 
-    # Data discrete — typed as AbstractArray so MTK stores it in the nonnumeric buffer
-    # while keeping scalar shape (avoids ifelse shape mismatch during substitute).
-    # Initial value is zeros; the discrete update event populates the buffer
-    # with real data at solve time.
+    # Data discrete — wrapped in `DataBufferType` so MTK stores it in the
+    # nonnumeric parameter buffer with scalar symbolic shape. Allocate via
+    # `similar(domain.u_proto, ...)` so the buffer inherits the array backend
+    # of the state vector (plain `Array` on CPU, `CuArray`/`ROCArray`/etc. on
+    # device). Element type comes from the interpolator's `To` parameter,
+    # which is derived from `eltype(domaininfo)`. Initial value is zeros; the
+    # discrete update event populates the buffer at solve time.
     n_data = Symbol(n, :_data)
-    init_data = zeros(To, data_dims...)
+    init_data = similar(itp.domain.u_proto, To, data_dims...)
+    fill!(init_data, zero(To))
     p_data = _make_array_discrete(n_data, init_data, length(data_dims),
         "Interpolation data for $(n)")
 
@@ -341,8 +375,15 @@ function build_interp_event(interp_infos, starttime::DateTime)
         for (ck, dsi) in pairs(ctx)
             lazyload!(dsi, integ.t + t_ref)
             km = key_map[ck]
-            result_vals[findfirst(==(km.data_key), mod_keys)] = DataBufferType(
-                copy(dsi.cache.data_buffer))
+            # Transfer the CPU-side `dsi.cache.data_buffer` into a buffer of
+            # the same backend as the state vector (`Array` on CPU,
+            # `CuArray`/etc. on device), preserving the element type of the
+            # domain's prototype array.  `copyto!` handles both same-device
+            # (memcpy) and cross-device (host→device) transfers.
+            src = dsi.cache.data_buffer
+            dst = similar(dsi.domain.u_proto, size(src)...)
+            copyto!(dst, src)
+            result_vals[findfirst(==(km.data_key), mod_keys)] = DataBufferType(dst)
             ts, tstep = get_time_grid_params(dsi)
             result_vals[findfirst(==(km.tstart_key), mod_keys)] = ts
             result_vals[findfirst(==(km.tstep_key), mod_keys)] = tstep

--- a/src/mtk_integration.jl
+++ b/src/mtk_integration.jl
@@ -100,15 +100,28 @@ function _make_array_discrete(name::Symbol, init_data, ndims::Int, desc::String)
     # device). Do NOT promote to Float64 here — that would break Float32
     # simulations and force all data buffers onto the host.
     #
-    # `@discretes` needs a concrete `DataType` for the `::T` annotation, and
+    # We use `@parameters` (not `@discretes $name(t)`) because the data buffer's
+    # *value* does not depend on `t` in a way that the symbolic differentiator
+    # can reason about — the value jumps discretely at callback fire times.
+    # Declaring it as `name(t)` made `executediff` produce a non-trivial
+    # `Differential(t)(name(t))` term during `calculate_tgrad`, whose symtype is
+    # `DataBufferType`; `mul_worker` then threw `MethodError(*, (Real,
+    # DataBufferType))` because the zero chain-rule factor from
+    # `@register_derivative interp_unsafe` can't be multiplied by it. Making
+    # the parameter time-independent short-circuits the derivative walk
+    # (`occursin_info(t, name) == false` => `COMMON_ZERO`).
+    # The discrete update event's `ImperativeAffect` writes to the parameter
+    # just the same whether it's `@parameters` or `@discretes`.
+    #
+    # `@parameters` needs a concrete `DataType` for the `::T` annotation, and
     # `DataBufferType` as a parameterized struct is a `UnionAll`.  Build the
     # concrete parameterization `DataBufferType{typeof(init_data)}` at runtime
-    # and feed it into `@discretes` via `@eval` so the macro sees a concrete
+    # and feed it into `@parameters` via `@eval` so the macro sees a concrete
     # type.  This is called a handful of times at model construction — the
     # `@eval` cost is in the noise compared to `mtkcompile`.
     BT = DataBufferType{typeof(init_data)}
     expr = quote
-        @discretes $name(t)::$BT = $init_data [description = $desc]
+        @parameters $name::$BT = $init_data [description = $desc]
     end
     return only(Core.eval(@__MODULE__, expr))
 end
@@ -196,9 +209,17 @@ function create_interp_equation(itp::DataSetInterpolator{To}, filename, t, t_ref
     n_tstep = Symbol(n, :_tstep)
     ts_default = EarthSciMLBase.get_tref(itp.domain)
     tstep_default = 1.0
-    p_tstart = only(@discretes $n_tstart(t) = ts_default [
+    # `@parameters` (not `@discretes`) — see rationale on `_make_array_discrete`.
+    # These parameters *are* updated by the discrete event at the same time
+    # `_data` is, but leaving them as `(t)`-dependent `@discretes` makes
+    # MTK attach a parameter timeseries slot which feeds a `SymbolCache` into
+    # the IMEX solver's solution-saving path and crashes in
+    # `get_saveable_values(::SymbolCache, ...)`.  Making them time-independent
+    # parameters bypasses that entire machinery; `ImperativeAffect` can still
+    # write to plain parameters.
+    p_tstart = only(@parameters $n_tstart = ts_default [
         unit = u"s", description = "Time grid start for $(n)"])
-    p_tstep = only(@discretes $n_tstep(t) = tstep_default [
+    p_tstep = only(@parameters $n_tstep = tstep_default [
         unit = u"s", description = "Time grid step for $(n)"])
 
     # Spatial grid constants (fixed for the lifetime of the simulation).

--- a/src/mtk_integration.jl
+++ b/src/mtk_integration.jl
@@ -18,7 +18,9 @@ Base.copy(x::DataBufferType) = DataBufferType(copy(x.data))
 # a DynamicQuantities.Quantity or an integer to get information about the type
 # and units of the output. The array-based interp_unsafe is unitless, so we
 # return a dimensionless value (units are applied via a separate @constants multiplier).
-interp_unsafe(data::Union{DynamicQuantities.AbstractQuantity, Real}, fit, args...) = one(Float64)
+function interp_unsafe(data::Union{DynamicQuantities.AbstractQuantity, Real}, fit, args...)
+    one(Float64)
+end
 
 # Runtime unwrap: when MTK calls interp_unsafe with a DataBufferType wrapper,
 # forward to the actual array-based implementation.
@@ -87,9 +89,10 @@ Create an equation that interpolates the given dataset at the given time and loc
 to divide the interpolated value by 2.
 
 Returns `(equation, discretes, constants, interp_info)` where:
-- `discretes`: vector of discrete symbolic variables [data, t_start, t_step]
-- `constants`: vector of constant symbolic variables [spatial grid params..., extrap, unit_scale]
-- `interp_info`: named tuple with all symbolic pieces needed to build interpolation expressions
+
+  - `discretes`: vector of discrete symbolic variables [data, t_start, t_step]
+  - `constants`: vector of constant symbolic variables [spatial grid params..., extrap, unit_scale]
+  - `interp_info`: named tuple with all symbolic pieces needed to build interpolation expressions
 """
 function create_interp_equation(itp::DataSetInterpolator{To}, filename, t, t_ref, coords;
         wrapper_f = v -> v) where {To}
@@ -115,8 +118,10 @@ function create_interp_equation(itp::DataSetInterpolator{To}, filename, t, t_ref
     n_tstart = Symbol(n, :_tstart)
     n_tstep = Symbol(n, :_tstep)
     ts_default, tstep_default = get_time_grid_params(itp)
-    p_tstart = only(@discretes $n_tstart(t) = ts_default [unit = u"s", description = "Time grid start for $(n)"])
-    p_tstep = only(@discretes $n_tstep(t) = tstep_default [unit = u"s", description = "Time grid step for $(n)"])
+    p_tstart = only(@discretes $n_tstart(t) = ts_default [
+        unit = u"s", description = "Time grid start for $(n)"])
+    p_tstep = only(@discretes $n_tstep(t) = tstep_default [
+        unit = u"s", description = "Time grid step for $(n)"])
 
     # Spatial grid constants (fixed for the lifetime of the simulation).
     # Each constant gets the same unit as the corresponding coordinate variable
@@ -127,12 +132,14 @@ function create_interp_equation(itp::DataSetInterpolator{To}, filename, t, t_ref
         coord_unit = ModelingToolkit.get_unit(coords[i])
         sn_start = Symbol(n, :_s, i, :start)
         sn_step = Symbol(n, :_s, i, :step)
-        push!(spatial_consts, only(@constants $sn_start = first(r) [
-            unit = coord_unit,
-            description = "Spatial grid start dim $(i) for $(n)"]))
-        push!(spatial_consts, only(@constants $sn_step = step(r) [
-            unit = coord_unit,
-            description = "Spatial grid step dim $(i) for $(n)"]))
+        push!(spatial_consts,
+            only(@constants $sn_start = first(r) [
+                unit = coord_unit,
+                description = "Spatial grid start dim $(i) for $(n)"]))
+        push!(spatial_consts,
+            only(@constants $sn_step = step(r) [
+                unit = coord_unit,
+                description = "Spatial grid step dim $(i) for $(n)"]))
     end
 
     # Extrapolation type constant: 1.0 = Flat (clamp), 0.0 = zero outside bounds.
@@ -149,7 +156,7 @@ function create_interp_equation(itp::DataSetInterpolator{To}, filename, t, t_ref
 
     # Compute fractional 1-based indices symbolically: fi = 1 + (coord - start) / step
     fit = 1 + (t_ref + t - p_tstart) / p_tstep
-    fis = [1 + (coords[i] - spatial_consts[2i-1]) / spatial_consts[2i]
+    fis = [1 + (coords[i] - spatial_consts[2i - 1]) / spatial_consts[2i]
            for i in 1:length(coords)]
 
     # Build RHS: interp_unsafe(data, fit, fi1, ..., extrap) * unit_scale
@@ -177,7 +184,7 @@ function create_interp_equation(itp::DataSetInterpolator{To}, filename, t, t_ref
     # Collect default values for constants (needed for initial_conditions in System).
     const_defaults = Dict{Any, Any}()
     for (i, r) in enumerate(grid_ranges)
-        const_defaults[spatial_consts[2i-1]] = first(r)
+        const_defaults[spatial_consts[2i - 1]] = first(r)
         const_defaults[spatial_consts[2i]] = step(r)
     end
     const_defaults[p_extrap] = extrap_val
@@ -202,7 +209,7 @@ the interpolation at modified coordinates (e.g., `lev + 1` for finite difference
 function build_interp_expr(info, t_expr, coord_exprs)
     fit = 1 + (t_expr - info.tstart_sym) / info.tstep_sym
     n_spatial = length(coord_exprs)
-    fis = [1 + (coord_exprs[i] - info.spatial_consts[2i-1]) / info.spatial_consts[2i]
+    fis = [1 + (coord_exprs[i] - info.spatial_consts[2i - 1]) / info.spatial_consts[2i]
            for i in 1:n_spatial]
     interp_unsafe(info.data_sym, fit, fis..., info.extrap_const) * info.unit_const
 end
@@ -298,9 +305,9 @@ function build_interp_event(interp_infos, starttime::DateTime)
     for (i, info) in enumerate(interp_infos)
         ck = Symbol(:itp_, info.var_sym)
         key_map[ck] = (
-            data_key = mod_keys[3*(i-1)+1],
-            tstart_key = mod_keys[3*(i-1)+2],
-            tstep_key = mod_keys[3*(i-1)+3],
+            data_key = mod_keys[3 * (i - 1) + 1],
+            tstart_key = mod_keys[3 * (i - 1) + 2],
+            tstep_key = mod_keys[3 * (i - 1) + 3]
         )
     end
 

--- a/src/mtk_integration.jl
+++ b/src/mtk_integration.jl
@@ -312,16 +312,20 @@ function build_interp_event(interp_infos, starttime::DateTime)
     end
 
     function update_data!(modified, observed, ctx, integ)
-        result = Dict{Symbol, Any}()
+        # Build result in the same order as mod_keys to guarantee the
+        # returned NamedTuple matches the `modified` declaration order.
+        # (Dict iteration order is not guaranteed in Julia.)
+        result_vals = Vector{Any}(undef, length(mod_keys))
         for (ck, dsi) in pairs(ctx)
             lazyload!(dsi, integ.t + t_ref)
             km = key_map[ck]
-            result[km.data_key] = DataBufferType(copy(dsi.cache.data_buffer))
+            result_vals[findfirst(==(km.data_key), mod_keys)] = DataBufferType(
+                copy(dsi.cache.data_buffer))
             ts, tstep = get_time_grid_params(dsi)
-            result[km.tstart_key] = ts
-            result[km.tstep_key] = tstep
+            result_vals[findfirst(==(km.tstart_key), mod_keys)] = ts
+            result_vals[findfirst(==(km.tstep_key), mod_keys)] = tstep
         end
-        NamedTuple{Tuple(keys(result))}(Tuple(values(result)))
+        NamedTuple{Tuple(mod_keys)}(Tuple(result_vals))
     end
 
     affect = ModelingToolkit.ImperativeAffect(

--- a/src/mtk_integration.jl
+++ b/src/mtk_integration.jl
@@ -2,35 +2,81 @@
 # This file contains symbolic registration, equation creation, and
 # system event generation that depend on ModelingToolkit.
 
-"""
-Return the units of the data.
-"""
-ModelingToolkit.get_unit(itp::DataSetInterpolator) = units(itp)
+# Custom symtype for data buffer discretes. Using a non-Real, non-AbstractArray
+# type gives scalar symbolic shape (so canonicalize_eq! works) while routing
+# values to MTK's nonnumeric parameter buffer (is_variable_floatingpoint returns false).
+# Concrete wrapper so that MTK's Vector{DataBufferType} buffer can hold array values
+# via convert(DataBufferType, array).
+struct DataBufferType
+    data::Any
+end
+Base.convert(::Type{DataBufferType}, x::DataBufferType) = x
+Base.convert(::Type{DataBufferType}, x) = DataBufferType(x)
+Base.copy(x::DataBufferType) = DataBufferType(copy(x.data))
 
-mutable struct ITPWrapper{ITP}
-    itp::ITP
-    ITPWrapper(itp::ITP) where {ITP} = new{ITP}(itp)
+# Dummy function for unit validation. ModelingToolkit calls the function with
+# a DynamicQuantities.Quantity or an integer to get information about the type
+# and units of the output. The array-based interp_unsafe is unitless, so we
+# return a dimensionless value (units are applied via a separate @constants multiplier).
+interp_unsafe(data::Union{DynamicQuantities.AbstractQuantity, Real}, fit, args...) = one(Float64)
+
+# Runtime unwrap: when MTK calls interp_unsafe with a DataBufferType wrapper,
+# forward to the actual array-based implementation.
+interp_unsafe(data::DataBufferType, fit, args...) = interp_unsafe(data.data, fit, args...)
+
+# Symbolic tracing for array-based interp_unsafe.
+# Arguments are: data, fit (fractional time index), fi1..fiN (fractional spatial indices), extrap.
+# Fractional indices are computed in the symbolic equation: fi = 1 + (coord - start) / step
+# DataBufferType is used as the symtype for the data buffer discrete parameter.
+# 3 spatial dims + time (4D array): data, fit, fi1, fi2, fi3, extrap = 6 args
+@register_symbolic interp_unsafe(data::DataBufferType, fit, fi1, fi2, fi3, extrap) false
+# 2 spatial dims + time (3D array): data, fit, fi1, fi2, extrap = 5 args
+@register_symbolic interp_unsafe(data::DataBufferType, fit, fi1, fi2, extrap) false
+# 1 spatial dim + time (2D array): data, fit, fi1, extrap = 4 args
+@register_symbolic interp_unsafe(data::DataBufferType, fit, fi1, extrap) false
+
+# Tell SymbolicUtils that interp_unsafe always returns a Real scalar.
+# promote_symtype: @register_symbolic generates promote_symtype dispatches for the
+# declared argument types, but DataBufferType needs explicit overrides since
+# the fallback may not handle it correctly.
+for n_args in 4:6
+    @eval Symbolics.SymbolicUtils.promote_symtype(::typeof(interp_unsafe),
+        ::Type{DataBufferType}, $(fill(:(::Type), n_args - 2)...), ::Type) = Real
 end
 
-(itp::ITPWrapper)(t, locs::Vararg{T, N}) where {T, N} = interp_unsafe(itp.itp, t, locs...)
+# Register zero derivatives for interp_unsafe. The data is updated discretely via
+# callbacks (not continuously), so the symbolic derivative is zero for all arguments.
+# Without this, calculate_tgrad creates unevaluated Differential terms with symtype Any,
+# which causes *(::Type{Any}, ::Type{Real}) errors in the IMEX solver path.
+@register_derivative interp_unsafe(args...) I Symbolics.SConst(zero(Float64))
 
-# Dummy functions for unit validation. Basically ModelingToolkit
-# will call the function with a DynamicQuantities.Quantity or an integer to
-# get information about the type and units of the output.
-interp(itp::Union{DynamicQuantities.AbstractQuantity, Real}, t, locs...) = itp
-interp_unsafe(itp::Union{DynamicQuantities.AbstractQuantity, Real}, t, locs...) = itp
+# Tell SymbolicUtils that interp_unsafe always returns a scalar shape.
+# Without this, maketerm's default promote_shape returns Unknown(-1) when rebuilding
+# during substitute, which breaks ifelse shape checks.
+const _scalar_shape = Symbolics.SymbolicUtils.ShapeVecT()
+for n_args in 4:6
+    @eval Symbolics.SymbolicUtils.promote_shape(::typeof(interp_unsafe),
+        $(fill(:(::Symbolics.SymbolicUtils.ShapeT), n_args)...)) = _scalar_shape
+end
 
-# Symbolic tracing, for different numbers of dimensions (up to three dimensions).
-@register_symbolic interp(itp::DataSetInterpolator, t, loc1, loc2, loc3)
-@register_symbolic interp(itp::DataSetInterpolator, t, loc1, loc2) false
-@register_symbolic interp(itp::DataSetInterpolator, t, loc1) false
-@register_symbolic interp_unsafe(itp::DataSetInterpolator, t, loc1, loc2, loc3)
-@register_symbolic interp_unsafe(itp::DataSetInterpolator, t, loc1, loc2) false
-@register_symbolic interp_unsafe(itp::DataSetInterpolator, t, loc1) false
+# Fix SymbolicUtils bug: promote_shape for ifelse returns `true` (Bool) instead of the
+# shape when branches match, because `sht == shf || error(...)` returns `true`.
+# This causes parse_shape(::Bool) errors when maketerm rebuilds ifelse during substitute.
+# Must be done in __init__ because method overwriting is not allowed during precompilation.
+function _fix_ifelse_promote_shape()
+    @eval Symbolics.SymbolicUtils function promote_shape(::typeof(ifelse),
+            shc::ShapeT, sht::ShapeT, shf::ShapeT)
+        @nospecialize shc sht shf
+        is_array_shape(shc) && error("Condition of `ifelse` cannot be an array.")
+        sht == shf || error("Both branches of `ifelse` must have the same shape.")
+        return sht
+    end
+end
 
-@register_symbolic interp!(itp::DataSetInterpolator, t, loc1, loc2, loc3)
-@register_symbolic interp!(itp::DataSetInterpolator, t, loc1, loc2) false
-@register_symbolic interp!(itp::DataSetInterpolator, t, loc1) false
+function _make_array_discrete(name::Symbol, init_data, ndims::Int, desc::String)
+    return only(@discretes $name(t)::DataBufferType = Float64.(init_data) [
+        description = desc])
+end
 
 """
 $(SIGNATURES)
@@ -39,39 +85,126 @@ Create an equation that interpolates the given dataset at the given time and loc
 `filename` is an identifier for the dataset, and `t` is the time variable.
 `wrapper_f` can specify a function to wrap the interpolated value, for example `eq -> eq / 2`
 to divide the interpolated value by 2.
+
+Returns `(equation, discretes, constants, interp_info)` where:
+- `discretes`: vector of discrete symbolic variables [data, t_start, t_step]
+- `constants`: vector of constant symbolic variables [spatial grid params..., extrap, unit_scale]
+- `interp_info`: named tuple with all symbolic pieces needed to build interpolation expressions
 """
-function create_interp_equation(itp::DataSetInterpolator, filename, t, t_ref, coords;
-        wrapper_f = v -> v)
+function create_interp_equation(itp::DataSetInterpolator{To}, filename, t, t_ref, coords;
+        wrapper_f = v -> v) where {To}
     n = length(filename) > 0 ? Symbol("$(filename)₊$(itp.varname)") :
         Symbol("$(itp.varname)")
-    n_p = Symbol(n, "_itp")
 
-    itp = ITPWrapper(itp)
-    t_itp = typeof(itp)
-    p_itp = only(
-        @parameters ($n_p::t_itp)(..)=itp [
-        unit = units(itp.itp),
-        description = "Interpolated $(n)"
-    ]
-    )
+    # Compute the correct data array dimensions from the model grid.
+    grid_ranges = _model_grid(itp)
+    grid_dims = length.(grid_ranges)
+    cache_nt = size(itp.cache.data_buffer, ndims(itp.cache.data_buffer))
+    data_dims = (grid_dims..., cache_nt)
 
-    # Create right hand side of equation.
-    rhs = wrapper_f(p_itp(t_ref + t, coords...))
+    # Data discrete — typed as AbstractArray so MTK stores it in the nonnumeric buffer
+    # while keeping scalar shape (avoids ifelse shape mismatch during substitute).
+    # Initial value is zeros; the discrete update event populates the buffer
+    # with real data at solve time.
+    n_data = Symbol(n, :_data)
+    init_data = zeros(To, data_dims...)
+    p_data = _make_array_discrete(n_data, init_data, length(data_dims),
+        "Interpolation data for $(n)")
+
+    # Time grid discretes — scalar defaults work fine in MTK.
+    n_tstart = Symbol(n, :_tstart)
+    n_tstep = Symbol(n, :_tstep)
+    ts_default, tstep_default = get_time_grid_params(itp)
+    p_tstart = only(@discretes $n_tstart(t) = ts_default [unit = u"s", description = "Time grid start for $(n)"])
+    p_tstep = only(@discretes $n_tstep(t) = tstep_default [unit = u"s", description = "Time grid step for $(n)"])
+
+    # Spatial grid constants (fixed for the lifetime of the simulation).
+    # Each constant gets the same unit as the corresponding coordinate variable
+    # (e.g., meters for Lambert, radians for longlat) so that fi = 1 + (coord - start) / step
+    # is dimensionally consistent.
+    spatial_consts = []
+    for (i, r) in enumerate(grid_ranges)
+        coord_unit = ModelingToolkit.get_unit(coords[i])
+        sn_start = Symbol(n, :_s, i, :start)
+        sn_step = Symbol(n, :_s, i, :step)
+        push!(spatial_consts, only(@constants $sn_start = first(r) [
+            unit = coord_unit,
+            description = "Spatial grid start dim $(i) for $(n)"]))
+        push!(spatial_consts, only(@constants $sn_step = step(r) [
+            unit = coord_unit,
+            description = "Spatial grid step dim $(i) for $(n)"]))
+    end
+
+    # Extrapolation type constant: 1.0 = Flat (clamp), 0.0 = zero outside bounds.
+    n_extrap = Symbol(n, :_extrap)
+    extrap_val = itp.extrapolate_type isa Real ? 0.0 : 1.0
+    p_extrap = only(@constants $n_extrap = extrap_val [
+        description = "Extrapolation type for $(n)"])
+
+    # Unit scale constant: the raw array data is unitless, so multiply by data units.
+    uu = units(itp)
+    n_unit = Symbol(n, :_unit)
+    unit_scale = only(@constants $n_unit = 1.0 [unit = uu,
+        description = "Unit scale for $(n)"])
+
+    # Compute fractional 1-based indices symbolically: fi = 1 + (coord - start) / step
+    fit = 1 + (t_ref + t - p_tstart) / p_tstep
+    fis = [1 + (coords[i] - spatial_consts[2i-1]) / spatial_consts[2i]
+           for i in 1:length(coords)]
+
+    # Build RHS: interp_unsafe(data, fit, fi1, ..., extrap) * unit_scale
+    rhs_interp = interp_unsafe(p_data, fit, fis..., p_extrap) * unit_scale
+
+    # Apply wrapper (e.g., NEI scaling).
+    rhs = wrapper_f(rhs_interp)
 
     # Create left hand side of equation.
-    desc = description(itp.itp)
-    uu = ModelingToolkit.get_unit(rhs)
+    desc = description(itp)
+    uu_rhs = ModelingToolkit.get_unit(rhs)
     lhs = only(
         @variables $n(t) [
-        unit = uu,
+        unit = uu_rhs,
         description = desc,
-        misc = Dict(:staggering => itp.itp.metadata.staggering)
+        misc = Dict(:staggering => itp.metadata.staggering)
     ]
     )
 
     eq = lhs ~ rhs
 
-    return eq, p_itp
+    discretes = [p_data, p_tstart, p_tstep]
+    constants = [spatial_consts..., p_extrap, unit_scale]
+
+    # Collect default values for constants (needed for initial_conditions in System).
+    const_defaults = Dict{Any, Any}()
+    for (i, r) in enumerate(grid_ranges)
+        const_defaults[spatial_consts[2i-1]] = first(r)
+        const_defaults[spatial_consts[2i]] = step(r)
+    end
+    const_defaults[p_extrap] = extrap_val
+    const_defaults[unit_scale] = 1.0
+
+    interp_info = (data_sym = p_data, tstart_sym = p_tstart, tstep_sym = p_tstep,
+        spatial_consts = spatial_consts, extrap_const = p_extrap,
+        unit_const = unit_scale, itp = itp, var_sym = n,
+        data_dims = data_dims, data_eltype = To,
+        const_defaults = const_defaults)
+
+    return eq, discretes, constants, interp_info
+end
+
+"""
+$(SIGNATURES)
+
+Build a symbolic interpolation expression for the given `interp_info` at the given
+time expression and coordinate expressions. This is useful when you need to evaluate
+the interpolation at modified coordinates (e.g., `lev + 1` for finite differences).
+"""
+function build_interp_expr(info, t_expr, coord_exprs)
+    fit = 1 + (t_expr - info.tstart_sym) / info.tstep_sym
+    n_spatial = length(coord_exprs)
+    fis = [1 + (coord_exprs[i] - info.spatial_consts[2i-1]) / info.spatial_consts[2i]
+           for i in 1:n_spatial]
+    interp_unsafe(info.data_sym, fit, fis..., info.extrap_const) * info.unit_const
 end
 
 # In MTK v11, parameter defaults set via `@parameters x = val` are stored as
@@ -86,7 +219,17 @@ function _itp_defaults(params)
     dflts = Pair[]
     for p in params
         if ModelingToolkit.hasdefault(p)
-            push!(dflts, p => ModelingToolkit.getdefault(p))
+            val = ModelingToolkit.getdefault(p)
+            if val isa AbstractArray
+                # Array-valued discretes (from @discretes) need to be wrapped
+                # in `DataBufferType` so they route to MTK's nonnumeric buffer.
+                # This provides the initial value for direct-`mtkcompile` users
+                # (e.g. `mtkcompile(GEOSFP(...))`) who bypass the CoupledSystem
+                # `sys_event` pathway that would otherwise seed these.
+                push!(dflts, p => DataBufferType(val))
+            else
+                push!(dflts, p => val)
+            end
         end
     end
     return dflts
@@ -98,45 +241,87 @@ function needed_vars(sys)
     exprs = [eq.rhs for eq in equations(sys)]
     needed_eqs = vcat(equations(sys),
         observed(sys)[ModelingToolkit.observed_equations_used_by(sys, exprs)])
-    needed_vars = unique(vcat(get_variables.(needed_eqs)...))
-    EarthSciMLBase.var2symbol.(needed_vars)
+    all_vars = Set{Any}()
+    for eq in needed_eqs
+        union!(all_vars, get_variables(eq))
+    end
+    EarthSciMLBase.var2symbol.(collect(all_vars))
 end
 
-# Create a "system event" (https://base.earthsci.dev/dev/system_events/)
-# to update the interpolators associated with the given parameters.
-function create_updater_sys_event(name, params, starttime::DateTime)
-    pnames = Symbol.((name,), (:₊,), EarthSciMLBase.var2symbol.(params))
+# Build a preset-time `SymbolicDiscreteCallback` that reloads the
+# interpolation data buffers at each dataset time stop. The event uses the
+# bare (un-namespaced) parameter symbols from `interp_infos`; MTK's
+# `namespace_affect` rewrites them when this event is attached to a subsystem
+# that later gets composed into a parent system. Attaching this directly to
+# the data loader's `System` means both `mtkcompile(loader)` and
+# `convert(System, couple(loader, ...))` pick it up automatically through
+# the standard discrete-events machinery.
+#
+# The same affect is registered as the callback's `initialize` so it runs at
+# problem init — populating the parameter buffer at `tspan[1]` before any
+# parameter query or the first RHS evaluation. This makes direct
+# `getsym(prob, ...)` return real data without having to run `solve`.
+function build_interp_event(interp_infos, starttime::DateTime)
     t_ref = datetime2unix(starttime)
-    function sys_event(sys::ModelingToolkit.AbstractSystem)
-        needed = needed_vars(sys)
-        psyms = []
-        params_to_update = []
-        for p in parameters(sys) # Figure out which parameters need to be updated.
-            psym = EarthSciMLBase.var2symbol(p)
-            if (psym in pnames) && (psym in needed) && ModelingToolkit.hasdefault(p) && ModelingToolkit.getdefault(p) isa ITPWrapper
-                push!(psyms, psym)
-                push!(params_to_update, p)
-            end
-        end
-        params_to_update = NamedTuple{Tuple(psyms)}(params_to_update)
-        all_tstops = []
-        for p_itp in params_to_update
-            itp = ModelingToolkit.getdefault(p_itp).itp
-            push!(all_tstops, get_tstops(itp, starttime)...)
-        end
-        all_tstops = unique(all_tstops) .- t_ref
-        function update_itps!(modified, observed, ctx, integ)
-            function loadf(p_itp)
-                p_itp.itp = lazyload!(p_itp.itp, integ.t + t_ref)
-                return p_itp
-            end
-            NamedTuple((k => loadf(v) for (k, v) in pairs(modified)))
-        end
-        if length(params_to_update) == 0
-            return nothing
-        end
-        all_tstops => (update_itps!, params_to_update, NamedTuple())
+
+    # Compute all time stops across all interpolators.
+    all_tstops = Float64[]
+    for info in interp_infos
+        append!(all_tstops, get_tstops(info.itp, starttime))
     end
+    all_tstops = unique(all_tstops) .- t_ref
+
+    # Build modified NamedTuple using bare subsystem syms.
+    mod_keys = Symbol[]
+    mod_vals = []
+    for info in interp_infos
+        push!(mod_keys, EarthSciMLBase.var2symbol(info.data_sym))
+        push!(mod_vals, info.data_sym)
+        push!(mod_keys, EarthSciMLBase.var2symbol(info.tstart_sym))
+        push!(mod_vals, info.tstart_sym)
+        push!(mod_keys, EarthSciMLBase.var2symbol(info.tstep_sym))
+        push!(mod_vals, info.tstep_sym)
+    end
+    modified_nt = NamedTuple{Tuple(mod_keys)}(Tuple(mod_vals))
+
+    # Build context NamedTuple: `DataSetInterpolator` objects.
+    ctx_keys = Symbol[]
+    ctx_vals = []
+    for info in interp_infos
+        push!(ctx_keys, Symbol(:itp_, info.var_sym))
+        push!(ctx_vals, info.itp)
+    end
+    ctx_nt = NamedTuple{Tuple(ctx_keys)}(Tuple(ctx_vals))
+
+    # Map ctx key → (data_key, tstart_key, tstep_key) for the update callback.
+    key_map = Dict{Symbol, NamedTuple}()
+    for (i, info) in enumerate(interp_infos)
+        ck = Symbol(:itp_, info.var_sym)
+        key_map[ck] = (
+            data_key = mod_keys[3*(i-1)+1],
+            tstart_key = mod_keys[3*(i-1)+2],
+            tstep_key = mod_keys[3*(i-1)+3],
+        )
+    end
+
+    function update_data!(modified, observed, ctx, integ)
+        result = Dict{Symbol, Any}()
+        for (ck, dsi) in pairs(ctx)
+            lazyload!(dsi, integ.t + t_ref)
+            km = key_map[ck]
+            result[km.data_key] = DataBufferType(copy(dsi.cache.data_buffer))
+            ts, tstep = get_time_grid_params(dsi)
+            result[km.tstart_key] = ts
+            result[km.tstep_key] = tstep
+        end
+        NamedTuple{Tuple(keys(result))}(Tuple(values(result)))
+    end
+
+    affect = ModelingToolkit.ImperativeAffect(
+        update_data!; modified = modified_nt, observed = NamedTuple(), ctx = ctx_nt)
+
+    return ModelingToolkit.SymbolicDiscreteCallback(
+        all_tstops, affect; initialize = affect)
 end
 
 Latexify.@latexrecipe function f(itp::EarthSciData.DataSetInterpolator)

--- a/src/mtk_integration.jl
+++ b/src/mtk_integration.jl
@@ -408,8 +408,16 @@ function build_interp_event(interp_infos, starttime::DateTime)
     affect = ModelingToolkit.ImperativeAffect(
         update_data!; modified = modified_nt, observed = NamedTuple(), ctx = ctx_nt)
 
+    # `initialize_save_discretes = false`: the data buffer parameters are
+    # internal bookkeeping, not user-visible state, so we don't need MTK to
+    # save them on the initialize affect.  This avoids a spurious
+    # `sol.t == [tspan[1], tspan[1], ...]` duplicate at the start of the
+    # solution.  Note: `save_positions` on the underlying `PresetTimeCallback`
+    # may still produce extra entries; downstream code should use
+    # `sol(saveat)` rather than `sol.u` indexing for fixed-size sampling.
     return ModelingToolkit.SymbolicDiscreteCallback(
-        all_tstops, affect; initialize = affect)
+        all_tstops, affect; initialize = affect,
+        initialize_save_discretes = false)
 end
 
 Latexify.@latexrecipe function f(itp::EarthSciData.DataSetInterpolator)

--- a/src/nei2016monthly.jl
+++ b/src/nei2016monthly.jl
@@ -1,12 +1,19 @@
 export NEI2016MonthlyEmis
 
 # Diurnal scale factors for 24 hours (0-23) for UTC-0
-const DIURNAL_FACTORS = [0.45, 0.45, 0.6, 0.6, 0.6, 0.6, 1.45, 1.45, 1.45, 1.45, 1.4, 1.4, 1.4, 1.4, 1.45, 1.45, 1.45, 1.45, 0.65, 0.65, 0.65, 0.65, 0.45, 0.45]
-const DIURNAL_FACTORS_NOx = [0.39598674, 0.31852847, 0.30128068, 0.29590213, 0.33177775, 0.43871498, 0.9094625, 1.5850095, 1.6223788, 1.3429453, 1.2265036, 1.1937649, 1.254314, 1.3282939, 1.331211, 1.4135737, 1.6848333, 1.710925, 1.3491899, 1.0586671, 0.84439224, 0.761263, 0.72693235, 0.5741503]
-const DIURNAL_FACTORS_ISOP =[0,0,0,0,0,0, 0.2376,0.7224,1.2048,1.656,2.0496,2.3616,2.5728,2.6616,2.6184,2.4408,2.1288,1.6896,1.1448,0.5136, 0,0,0,0]
+const DIURNAL_FACTORS = [0.45, 0.45, 0.6, 0.6, 0.6, 0.6, 1.45, 1.45, 1.45, 1.45, 1.4, 1.4,
+    1.4, 1.4, 1.45, 1.45, 1.45, 1.45, 0.65, 0.65, 0.65, 0.65, 0.45, 0.45]
+const DIURNAL_FACTORS_NOx = [
+    0.39598674, 0.31852847, 0.30128068, 0.29590213, 0.33177775, 0.43871498,
+    0.9094625, 1.5850095, 1.6223788, 1.3429453, 1.2265036, 1.1937649,
+    1.254314, 1.3282939, 1.331211, 1.4135737, 1.6848333, 1.710925,
+    1.3491899, 1.0586671, 0.84439224, 0.761263, 0.72693235, 0.5741503]
+const DIURNAL_FACTORS_ISOP = [
+    0, 0, 0, 0, 0, 0, 0.2376, 0.7224, 1.2048, 1.656, 2.0496, 2.3616, 2.5728,
+    2.6616, 2.6184, 2.4408, 2.1288, 1.6896, 1.1448, 0.5136, 0, 0, 0, 0]
 
-const DayofWeekFactors_NOx = [1.0706,1.0706,1.0706,1.0706,1.0706,0.863,0.784]
-const DayofWeekFactors_CO = [1.076,1.1076,1.0706,1.0706,1.0706,0.779,0.683]
+const DayofWeekFactors_NOx = [1.0706, 1.0706, 1.0706, 1.0706, 1.0706, 0.863, 0.784]
+const DayofWeekFactors_CO = [1.076, 1.1076, 1.0706, 1.0706, 1.0706, 0.779, 0.683]
 
 # Load and create interpolator for delp_dry_surface
 const DELP_DRY_SURFACE_ITP = let
@@ -126,7 +133,7 @@ end
 # Tell SymbolicUtils these registered functions return scalars (needed for maketerm rebuild
 # during substitute to avoid Unknown(-1) shapes breaking ifelse).
 for f in (diurnal_itp, diurnal_itp_NOx, diurnal_itp_ISOP,
-          dayofweek_itp_CO, dayofweek_itp_NOx, delp_dry_surface_itp)
+    dayofweek_itp_CO, dayofweek_itp_NOx, delp_dry_surface_itp)
     @eval Symbolics.SymbolicUtils.promote_shape(::typeof($f),
         ::Symbolics.SymbolicUtils.ShapeT, ::Symbolics.SymbolicUtils.ShapeT) = _scalar_shape
 end
@@ -279,23 +286,24 @@ function loadmetadata(fs::NEI2016MonthlyEmisFileSet, varname)::MetaData
 end
 
 function get_geometry(fs::NEI2016MonthlyEmisFileSet, m::MetaData)
-    x₀,y₀,Δx,Δy,nx,ny = lock(nclock) do
+    x₀, y₀, Δx, Δy, nx, ny = lock(nclock) do
         x₀ = fs.ds.attrib["XORIG"]
         y₀ = fs.ds.attrib["YORIG"]
         Δx = fs.ds.attrib["XCELL"]
         Δy = fs.ds.attrib["YCELL"]
         nx = fs.ds.attrib["NCOLS"]
         ny = fs.ds.attrib["NROWS"]
-        x₀,y₀,Δx,Δy,nx,ny
+        x₀, y₀, Δx, Δy, nx, ny
     end
     # Create edges (nx+1 and ny+1 points) so we get nx*ny cells
-    x = range(start=x₀, step=Δx, length=nx+1)
-    y = range(start=y₀, step=Δy, length=ny+1)
+    x = range(start = x₀, step = Δx, length = nx+1)
+    y = range(start = y₀, step = Δy, length = ny+1)
     # Use column-major (x-fastest) ordering to match vec() on data arrays
     polys = Vector{Vector{NTuple{2, Float64}}}(undef, nx*ny)
     for j in 1:ny, i in 1:nx
-        polys[(j-1)*nx + i] = [(x[i], y[j]), (x[i+1], y[j]), (x[i+1], y[j+1]),
-            (x[i], y[j+1]), (x[i], y[j])]
+
+        polys[(j - 1) * nx + i] = [(x[i], y[j]), (x[i + 1], y[j]), (x[i + 1], y[j + 1]),
+            (x[i], y[j + 1]), (x[i], y[j])]
     end
     return polys
 end
@@ -311,7 +319,10 @@ function varnames(fs::NEI2016MonthlyEmisFileSet)
     end
 end
 
-Base.close(fs::NEI2016MonthlyEmisFileSet) = lock(nclock) do; close(fs.ds); end
+Base.close(fs::NEI2016MonthlyEmisFileSet) =
+    lock(nclock) do ;
+        close(fs.ds);
+    end
 
 struct NEI2016MonthlyEmisCoupler
     sys::Any
@@ -345,7 +356,7 @@ function NEI2016MonthlyEmis(
         domaininfo::DomainInfo;
         scale = 1.0,
         name = :NEI2016MonthlyEmis,
-        stream = true,
+        stream = true
 )
     starttime, endtime = get_tspan_datetime(domaininfo)
     _fs = NEI2016MonthlyEmisFileSet(sector, starttime, endtime)
@@ -389,25 +400,32 @@ function NEI2016MonthlyEmis(
         # The conversion is: mixing_ratio = flux / (g0_100 * delp_dry_surface(x, y))
         if varname in ["CO"]
             wrapper_f = (eq) -> ifelse(lev < 2,
-                eq / Δz * scale * dayofweek_itp_CO(t + t_ref, x) * diurnal_itp(t + t_ref, x) / (g0_100 * delp_dry_surface_itp(x, y)),
+                eq / Δz * scale * dayofweek_itp_CO(t + t_ref, x) *
+                diurnal_itp(t + t_ref, x) / (g0_100 * delp_dry_surface_itp(x, y)),
                 zero_emis)
         elseif varname in ["FORM"]
             wrapper_f = (eq) -> ifelse(lev < 2,
-                eq / Δz * scale * diurnal_itp(t + t_ref, x) / (g0_100 * delp_dry_surface_itp(x, y)),
+                eq / Δz * scale * diurnal_itp(t + t_ref, x) /
+                (g0_100 * delp_dry_surface_itp(x, y)),
                 zero_emis)
         elseif varname in ["ISOP"]
             wrapper_f = (eq) -> ifelse(lev < 2,
-                eq / Δz * scale * diurnal_itp_ISOP(t + t_ref, x) / (g0_100 * delp_dry_surface_itp(x, y)),
+                eq / Δz * scale * diurnal_itp_ISOP(t + t_ref, x) /
+                (g0_100 * delp_dry_surface_itp(x, y)),
                 zero_emis)
         elseif varname in ["NO2", "NO"]
             wrapper_f = (eq) -> ifelse(lev < 2,
-                eq / Δz * scale * dayofweek_itp_NOx(t + t_ref, x) * diurnal_itp_NOx(t + t_ref, x) / (g0_100 * delp_dry_surface_itp(x, y)),
+                eq / Δz * scale * dayofweek_itp_NOx(t + t_ref, x) *
+                diurnal_itp_NOx(t + t_ref, x) / (g0_100 * delp_dry_surface_itp(x, y)),
                 zero_emis)
         else
-            wrapper_f = (eq) -> ifelse(lev < 2, eq / Δz * scale / (g0_100 * delp_dry_surface_itp(x, y)), zero_emis)
+            wrapper_f = (eq) -> ifelse(
+                lev < 2, eq / Δz * scale / (g0_100 * delp_dry_surface_itp(x, y)), zero_emis)
         end
 
-        eq, discretes, constants, info = create_interp_equation(itp, "", t, t_ref, [x, y];
+        eq, discretes,
+        constants,
+        info = create_interp_equation(itp, "", t, t_ref, [x, y];
             wrapper_f = wrapper_f)
         push!(eqs, eq)
         append!(all_discretes, discretes)
@@ -429,4 +447,3 @@ function NEI2016MonthlyEmis(
     )
     return sys
 end
-

--- a/src/nei2016monthly.jl
+++ b/src/nei2016monthly.jl
@@ -347,6 +347,10 @@ that varies spatially across the domain.
 
 `stream` specifies whether the data should be streamed in as needed or loaded all at once.
 
+`spatial_interp = :linear` (default) does full multilinear interpolation; `:nearest` does
+spatial nearest-neighbour + time-only linear interpolation for ~8x speedup when queries
+are always at grid points.
+
 Conservative regridding (via ConservativeRegridding.jl) is used by default to map emissions
 from the native NEI Lambert Conformal Conic grid to the simulation domain grid, preserving
 total emissions mass.
@@ -356,7 +360,8 @@ function NEI2016MonthlyEmis(
         domaininfo::DomainInfo;
         scale = 1.0,
         name = :NEI2016MonthlyEmis,
-        stream = true
+        stream = true,
+        spatial_interp::Symbol = :linear
 )
     starttime, endtime = get_tspan_datetime(domaininfo)
     _fs = NEI2016MonthlyEmisFileSet(sector, starttime, endtime)
@@ -426,7 +431,8 @@ function NEI2016MonthlyEmis(
         eq, discretes,
         constants,
         info = create_interp_equation(itp, "", t, t_ref, [x, y];
-            wrapper_f = wrapper_f)
+            wrapper_f = wrapper_f,
+            spatial_interp = spatial_interp)
         push!(eqs, eq)
         append!(all_discretes, discretes)
         append!(all_constants, constants)

--- a/src/nei2016monthly.jl
+++ b/src/nei2016monthly.jl
@@ -123,6 +123,14 @@ end
 @register_symbolic dayofweek_itp_NOx(t, lon)
 @register_symbolic delp_dry_surface_itp(lon, lat)
 
+# Tell SymbolicUtils these registered functions return scalars (needed for maketerm rebuild
+# during substitute to avoid Unknown(-1) shapes breaking ifelse).
+for f in (diurnal_itp, diurnal_itp_NOx, diurnal_itp_ISOP,
+          dayofweek_itp_CO, dayofweek_itp_NOx, delp_dry_surface_itp)
+    @eval Symbolics.SymbolicUtils.promote_shape(::typeof($f),
+        ::Symbolics.SymbolicUtils.ShapeT, ::Symbolics.SymbolicUtils.ShapeT) = _scalar_shape
+end
+
 # Dummy function for unit validation. ModelingToolkit will call this function
 # with a DynamicQuantities.Quantity to get information about the type and units of the output.
 diurnal_itp(t::DynamicQuantities.Quantity, lon) = 1.0
@@ -337,7 +345,7 @@ function NEI2016MonthlyEmis(
         domaininfo::DomainInfo;
         scale = 1.0,
         name = :NEI2016MonthlyEmis,
-        stream = true
+        stream = true,
 )
     starttime, endtime = get_tspan_datetime(domaininfo)
     _fs = NEI2016MonthlyEmisFileSet(sector, starttime, endtime)
@@ -350,6 +358,7 @@ function NEI2016MonthlyEmis(
     x = :x in keys(pvdict) ? pvdict[:x] : pvdict[:lon]
     y = :y in keys(pvdict) ? pvdict[:y] : pvdict[:lat]
     lev = pvdict[:lev]
+
     @parameters(Δz=1.0,
         [description = "Couldn't remove Δz without getting errors, so I set it to 1.0 without units"],)
     @parameters t_ref = get_tref(domaininfo) [unit = u"s", description = "Reference time"]
@@ -357,7 +366,10 @@ function NEI2016MonthlyEmis(
     @parameters g0_100 = 100.0 / 9.80665 [unit = u"kg/m^2"]
     eqs = Equation[]
     params = Any[t_ref, g0_100]
-    vars = Num[]
+    all_discretes = Any[]
+    all_constants = Any[]
+    interp_infos = []
+    lhs_vars = Num[]
 
     for varname in varnames(fs.fs)
         dt = EarthSciMLBase.eltype(domaininfo)
@@ -395,22 +407,24 @@ function NEI2016MonthlyEmis(
             wrapper_f = (eq) -> ifelse(lev < 2, eq / Δz * scale / (g0_100 * delp_dry_surface_itp(x, y)), zero_emis)
         end
 
-        eq, param = create_interp_equation(itp, "", t, t_ref, [x, y];
+        eq, discretes, constants, info = create_interp_equation(itp, "", t, t_ref, [x, y];
             wrapper_f = wrapper_f)
         push!(eqs, eq)
-        push!(params, param)
-        push!(vars, eq.lhs)
+        append!(all_discretes, discretes)
+        append!(all_constants, constants)
+        push!(interp_infos, info)
+        push!(lhs_vars, eq.lhs)
     end
-    all_params = [x, y, lev, Δz, params...]
+    all_params = [x, y, lev, Δz, all_constants..., all_discretes..., params...]
     sys = System(
         eqs,
         t,
-        vars,
+        lhs_vars,
         all_params;
         name = name,
         initial_conditions = _itp_defaults(all_params),
+        discrete_events = [build_interp_event(interp_infos, starttime)],
         metadata = Dict(CoupleType => NEI2016MonthlyEmisCoupler,
-            SysDiscreteEvent => create_updater_sys_event(name, params, starttime),
             SysDomainInfo => domaininfo)
     )
     return sys

--- a/src/openaq.jl
+++ b/src/openaq.jl
@@ -640,12 +640,13 @@ function OpenAQ(
     itp = DataSetInterpolator{dt}(fswr, parameter, starttime, endtime, domaininfo;
         stream = stream)
 
-    eq, param = create_interp_equation(itp, "", t, t_ref, [x, y])
+    eq, discretes, constants, info = create_interp_equation(
+        itp, "", t, t_ref, [x, y])
 
-    params = Any[t_ref, param]
     vars = [eq.lhs]
 
-    all_params = [x, y, params...]
+    all_params = [x, y, t_ref, constants..., discretes...]
+    interp_infos = [info]
     sys = System(
         [eq],
         t,
@@ -653,9 +654,9 @@ function OpenAQ(
         all_params;
         name = name,
         initial_conditions = _itp_defaults(all_params),
+        discrete_events = [build_interp_event(interp_infos, starttime)],
         metadata = Dict(
             CoupleType => OpenAQCoupler,
-            SysDiscreteEvent => create_updater_sys_event(name, params, starttime),
             SysDomainInfo => domaininfo,
         ),
     )

--- a/src/openaq.jl
+++ b/src/openaq.jl
@@ -9,16 +9,16 @@ const OPENAQ_API_BASE = "https://api.openaq.org/v3"
 
 # OpenAQ parameter name => (api_id, unit_string, description)
 const OPENAQ_PARAMETERS = Dict(
-    "pm25" => (id=2, unit="ug/m3", description="Particulate matter (PM2.5)"),
-    "pm10" => (id=1, unit="ug/m3", description="Particulate matter (PM10)"),
-    "o3" => (id=3, unit="ug/m3", description="Ozone"),
-    "no2" => (id=5, unit="ug/m3", description="Nitrogen dioxide"),
-    "so2" => (id=4, unit="ug/m3", description="Sulfur dioxide"),
-    "co" => (id=6, unit="ug/m3", description="Carbon monoxide"),
-    "bc" => (id=11, unit="ug/m3", description="Black carbon"),
-    "pm1" => (id=19, unit="ug/m3", description="Particulate matter (PM1)"),
-    "no" => (id=7, unit="ug/m3", description="Nitric oxide"),
-    "nox" => (id=8, unit="ug/m3", description="Nitrogen oxides"),
+    "pm25" => (id = 2, unit = "ug/m3", description = "Particulate matter (PM2.5)"),
+    "pm10" => (id = 1, unit = "ug/m3", description = "Particulate matter (PM10)"),
+    "o3" => (id = 3, unit = "ug/m3", description = "Ozone"),
+    "no2" => (id = 5, unit = "ug/m3", description = "Nitrogen dioxide"),
+    "so2" => (id = 4, unit = "ug/m3", description = "Sulfur dioxide"),
+    "co" => (id = 6, unit = "ug/m3", description = "Carbon monoxide"),
+    "bc" => (id = 11, unit = "ug/m3", description = "Black carbon"),
+    "pm1" => (id = 19, unit = "ug/m3", description = "Particulate matter (PM1)"),
+    "no" => (id = 7, unit = "ug/m3", description = "Nitric oxide"),
+    "nox" => (id = 8, unit = "ug/m3", description = "Nitrogen oxides")
 )
 
 """
@@ -63,7 +63,7 @@ struct OpenAQFileSet <: FileSet
     fill_value::Float64
     unit_scale::Float64
     # Precomputed mapping: grid_index => [station_indices...]
-    cell_stations::Dict{Tuple{Int,Int}, Vector{Int}}
+    cell_stations::Dict{Tuple{Int, Int}, Vector{Int}}
     # Per-instance cache: (location_id, date) => parsed rows for that parameter
     day_cache::Dict{Tuple{Int, Date}, Vector{Tuple{DateTime, Float64}}}
     day_cache_lock::ReentrantLock
@@ -87,18 +87,18 @@ Note: station coordinates (`lon`, `lat`) are in radians when the filter is appli
 `fill_value` is used for grid cells with no stations (default `0.0`).
 """
 function OpenAQFileSet(
-    parameter::AbstractString,
-    starttime::DateTime,
-    endtime::DateTime,
-    bbox::NamedTuple{(:lon_min, :lat_min, :lon_max, :lat_max)};
-    grid_lon_edges::AbstractVector{<:Real} = Float64[],
-    grid_lat_edges::AbstractVector{<:Real} = Float64[],
-    api_key::AbstractString = get(ENV, "OPENAQ_API_KEY", ""),
-    station_filter::Function = (_) -> true,
-    # TODO: fill_value should be `missing` or `NaN` so downstream code can
-    # distinguish cells with measurements from cells without. Currently 0.0
-    # because DataSetInterpolator's BSpline propagates NaN to the entire field.
-    fill_value::Real = 0.0,
+        parameter::AbstractString,
+        starttime::DateTime,
+        endtime::DateTime,
+        bbox::NamedTuple{(:lon_min, :lat_min, :lon_max, :lat_max)};
+        grid_lon_edges::AbstractVector{<:Real} = Float64[],
+        grid_lat_edges::AbstractVector{<:Real} = Float64[],
+        api_key::AbstractString = get(ENV, "OPENAQ_API_KEY", ""),
+        station_filter::Function = (_) -> true,
+        # TODO: fill_value should be `missing` or `NaN` so downstream code can
+        # distinguish cells with measurements from cells without. Currently 0.0
+        # because DataSetInterpolator's BSpline propagates NaN to the entire field.
+        fill_value::Real = 0.0
 )
     @assert !isempty(api_key) "OpenAQ API key is required. Set ENV[\"OPENAQ_API_KEY\"] or pass `api_key`."
     @assert !isempty(grid_lon_edges) "grid_lon_edges must be provided"
@@ -134,7 +134,7 @@ function OpenAQFileSet(
         Float64(unit_scale),
         cell_stations,
         Dict{Tuple{Int, Date}, Vector{Tuple{DateTime, Float64}}}(),
-        ReentrantLock(),
+        ReentrantLock()
     )
 end
 
@@ -143,11 +143,11 @@ Build a mapping from (i, j) grid cell indices to vectors of station indices.
 Grid edges are in radians.
 """
 function _build_cell_station_map(
-    stations::Vector{OpenAQStation},
-    lon_edges::Vector{Float64},
-    lat_edges::Vector{Float64},
+        stations::Vector{OpenAQStation},
+        lon_edges::Vector{Float64},
+        lat_edges::Vector{Float64}
 )
-    cell_stations = Dict{Tuple{Int,Int}, Vector{Int}}()
+    cell_stations = Dict{Tuple{Int, Int}, Vector{Int}}()
     nx = length(lon_edges) - 1
     ny = length(lat_edges) - 1
     for (si, st) in enumerate(stations)
@@ -170,10 +170,10 @@ Uses the OpenAQ v3 API with pagination. Results are cached locally.
 `bbox` values are in degrees.
 """
 function discover_stations(
-    parameter::AbstractString,
-    bbox::NamedTuple{(:lon_min, :lat_min, :lon_max, :lat_max)},
-    api_key::AbstractString,
-    station_filter::Function,
+        parameter::AbstractString,
+        bbox::NamedTuple{(:lon_min, :lat_min, :lon_max, :lat_max)},
+        api_key::AbstractString,
+        station_filter::Function
 )
     cache_dir = joinpath(download_cache(), "openaq_stations")
     mkpath(cache_dir)
@@ -199,7 +199,7 @@ function discover_stations(
             s["id"],
             get(s, "name", "unknown"),
             deg2rad(coords["longitude"]),
-            deg2rad(coords["latitude"]),
+            deg2rad(coords["latitude"])
         )
         if station_filter(st)
             push!(stations, st)
@@ -209,9 +209,9 @@ function discover_stations(
 end
 
 function _fetch_stations_from_api(
-    parameter::AbstractString,
-    bbox::NamedTuple{(:lon_min, :lat_min, :lon_max, :lat_max)},
-    api_key::AbstractString,
+        parameter::AbstractString,
+        bbox::NamedTuple{(:lon_min, :lat_min, :lon_max, :lat_max)},
+        api_key::AbstractString
 )
     all_results = Any[]
     page = 1
@@ -219,9 +219,9 @@ function _fetch_stations_from_api(
 
     while true
         url_str = "$(OPENAQ_API_BASE)/locations?" *
-            "bbox=$(bbox.lon_min),$(bbox.lat_min),$(bbox.lon_max),$(bbox.lat_max)" *
-            "&parameter_id=$(_parameter_id(parameter))" *
-            "&limit=$limit&page=$page"
+                  "bbox=$(bbox.lon_min),$(bbox.lat_min),$(bbox.lon_max),$(bbox.lat_max)" *
+                  "&parameter_id=$(_parameter_id(parameter))" *
+                  "&limit=$limit&page=$page"
 
         @info "OpenAQ: fetching stations page $page"
         body = _api_get(url_str, api_key)
@@ -247,7 +247,7 @@ function _api_get(url_str::AbstractString, api_key::AbstractString)
     headers = ["X-API-Key" => api_key, "Accept" => "application/json"]
     buf = IOBuffer()
     try
-        Downloads.download(url_str, buf; headers=headers)
+        Downloads.download(url_str, buf; headers = headers)
     catch e
         error("OpenAQ API request failed for $url_str: $e")
     end
@@ -263,9 +263,9 @@ $(SIGNATURES)
 Download daily CSV.gz files from the OpenAQ S3 archive for the given stations and time range.
 """
 function download_station_data(
-    stations::Vector{OpenAQStation},
-    starttime::DateTime,
-    endtime::DateTime,
+        stations::Vector{OpenAQStation},
+        starttime::DateTime,
+        endtime::DateTime
 )
     dates = Date(starttime):Day(1):Date(endtime)
     n_total = length(stations) * length(dates)
@@ -274,7 +274,7 @@ function download_station_data(
     n_downloaded = Threads.Atomic{Int}(0)
     n_skipped = Threads.Atomic{Int}(0)
 
-    asyncmap(tasks; ntasks=16) do (st, d)
+    asyncmap(tasks; ntasks = 16) do (st, d)
         p = _s3_localpath(st.id, d)
         if isfile(p)
             Threads.atomic_add!(n_skipped, 1)
@@ -289,7 +289,8 @@ function download_station_data(
             if e isa Downloads.RequestError
                 Threads.atomic_add!(n_skipped, 1)
             else
-                @warn "OpenAQ: unexpected error downloading $u" exception=(e, catch_backtrace())
+                @warn "OpenAQ: unexpected error downloading $u" exception=(
+                    e, catch_backtrace())
                 Threads.atomic_add!(n_skipped, 1)
             end
         end
@@ -320,7 +321,7 @@ function _s3_localpath(location_id::Int, d::Date)
         "locationid=$(location_id)",
         "year=$(yr)",
         "month=$(mo)",
-        "location-$(location_id)-$(day_str).csv.gz",
+        "location-$(location_id)-$(day_str).csv.gz"
     )
 end
 
@@ -343,10 +344,10 @@ function loadmetadata(fs::OpenAQFileSet, varname)::MetaData
     nx = length(fs.grid_lon_edges) - 1
     ny = length(fs.grid_lat_edges) - 1
 
-    lon_centers = [(fs.grid_lon_edges[i] + fs.grid_lon_edges[i+1]) / 2 for i in 1:nx]
-    lat_centers = [(fs.grid_lat_edges[j] + fs.grid_lat_edges[j+1]) / 2 for j in 1:ny]
+    lon_centers = [(fs.grid_lon_edges[i] + fs.grid_lon_edges[i + 1]) / 2 for i in 1:nx]
+    lat_centers = [(fs.grid_lat_edges[j] + fs.grid_lat_edges[j + 1]) / 2 for j in 1:ny]
 
-    info = get(OPENAQ_PARAMETERS, varname, (id=0, unit="ug/m3", description=varname))
+    info = get(OPENAQ_PARAMETERS, varname, (id = 0, unit = "ug/m3", description = varname))
     unit_str = info.unit
     desc = info.description
 
@@ -360,7 +361,7 @@ function loadmetadata(fs::OpenAQFileSet, varname)::MetaData
         1,  # xdim
         2,  # ydim
         -1, # zdim (no vertical)
-        (false, false, false),
+        (false, false, false)
     )
 end
 
@@ -371,9 +372,10 @@ function get_geometry(fs::OpenAQFileSet, m::MetaData)
     x = fs.grid_lon_edges
     y = fs.grid_lat_edges
     for j in 1:ny, i in 1:nx
-        polys[(j-1)*nx + i] = [
-            (x[i], y[j]), (x[i+1], y[j]), (x[i+1], y[j+1]),
-            (x[i], y[j+1]), (x[i], y[j]),
+
+        polys[(j - 1) * nx + i] = [
+            (x[i], y[j]), (x[i + 1], y[j]), (x[i + 1], y[j + 1]),
+            (x[i], y[j + 1]), (x[i], y[j])
         ]
     end
     polys
@@ -386,10 +388,10 @@ Load OpenAQ measurement data for the given time into `data`.
 Data is binned onto the grid by averaging all stations within each cell.
 """
 function loadslice!(
-    data::AbstractArray,
-    fs::OpenAQFileSet,
-    t::DateTime,
-    varname::String,
+        data::AbstractArray,
+        fs::OpenAQFileSet,
+        t::DateTime,
+        varname::String
 )
     @assert varname == fs.parameter
 
@@ -477,11 +479,11 @@ Returns `(total, count)` for computing an average.
 Uses cached daily data to avoid repeated decompression.
 """
 function _read_station_hour(
-    fs::OpenAQFileSet,
-    location_id::Int,
-    d::Date,
-    hour_start::DateTime,
-    hour_end::DateTime,
+        fs::OpenAQFileSet,
+        location_id::Int,
+        d::Date,
+        hour_start::DateTime,
+        hour_end::DateTime
 )
     rows = _load_station_day(fs, location_id, d)
     total = 0.0
@@ -587,16 +589,16 @@ observations for the given parameter.
 `stream` specifies whether data should be streamed or loaded all at once.
 """
 function OpenAQ(
-    parameter::AbstractString,
-    domaininfo::DomainInfo;
-    api_key::AbstractString = get(ENV, "OPENAQ_API_KEY", ""),
-    station_filter::Function = (_) -> true,
-    # TODO: fill_value should be `missing` or `NaN` so downstream code can
-    # distinguish cells with measurements from cells without. Currently 0.0
-    # because DataSetInterpolator's BSpline propagates NaN to the entire field.
-    fill_value::Real = 0.0,
-    name::Symbol = :OpenAQ,
-    stream::Bool = true,
+        parameter::AbstractString,
+        domaininfo::DomainInfo;
+        api_key::AbstractString = get(ENV, "OPENAQ_API_KEY", ""),
+        station_filter::Function = (_) -> true,
+        # TODO: fill_value should be `missing` or `NaN` so downstream code can
+        # distinguish cells with measurements from cells without. Currently 0.0
+        # because DataSetInterpolator's BSpline propagates NaN to the entire field.
+        fill_value::Real = 0.0,
+        name::Symbol = :OpenAQ,
+        stream::Bool = true
 )
     starttime, endtime = get_tspan_datetime(domaininfo)
 
@@ -608,7 +610,7 @@ function OpenAQ(
         lon_min = rad2deg(minimum(lon_edges)),
         lat_min = rad2deg(minimum(lat_edges)),
         lon_max = rad2deg(maximum(lon_edges)),
-        lat_max = rad2deg(maximum(lat_edges)),
+        lat_max = rad2deg(maximum(lat_edges))
     )
 
     fs = OpenAQFileSet(
@@ -617,7 +619,7 @@ function OpenAQ(
         grid_lat_edges = lat_edges,
         api_key = api_key,
         station_filter = station_filter,
-        fill_value = fill_value,
+        fill_value = fill_value
     )
 
     pvdict = Dict([Symbol(v) => v for v in EarthSciMLBase.pvars(domaininfo)]...)
@@ -635,7 +637,7 @@ function OpenAQ(
     # distinguish cells with measurements from cells without. Currently we use
     # 0.0 because the DataSetInterpolator builds a BSpline over the data array
     # and NaN in any cell propagates to the entire interpolated field.
-    copy_regridder = (dst, src; extrapolate_type=nothing) -> copyto!(dst, src)
+    copy_regridder = (dst, src; extrapolate_type = nothing) -> copyto!(dst, src)
     fswr = FileSetWithRegridder(fs, copy_regridder)
     itp = DataSetInterpolator{dt}(fswr, parameter, starttime, endtime, domaininfo;
         stream = stream)
@@ -657,8 +659,8 @@ function OpenAQ(
         discrete_events = [build_interp_event(interp_infos, starttime)],
         metadata = Dict(
             CoupleType => OpenAQCoupler,
-            SysDomainInfo => domaininfo,
-        ),
+            SysDomainInfo => domaininfo
+        )
     )
     return sys
 end

--- a/src/openaq.jl
+++ b/src/openaq.jl
@@ -587,6 +587,10 @@ observations for the given parameter.
 `fill_value` is used for grid cells with no stations (default `0.0`).
 
 `stream` specifies whether data should be streamed or loaded all at once.
+
+`spatial_interp = :linear` (default) does full multilinear interpolation; `:nearest` does
+spatial nearest-neighbour + time-only linear interpolation for ~8x speedup when queries
+are always at grid points.
 """
 function OpenAQ(
         parameter::AbstractString,
@@ -598,7 +602,8 @@ function OpenAQ(
         # because DataSetInterpolator's BSpline propagates NaN to the entire field.
         fill_value::Real = 0.0,
         name::Symbol = :OpenAQ,
-        stream::Bool = true
+        stream::Bool = true,
+        spatial_interp::Symbol = :linear
 )
     starttime, endtime = get_tspan_datetime(domaininfo)
 
@@ -642,8 +647,11 @@ function OpenAQ(
     itp = DataSetInterpolator{dt}(fswr, parameter, starttime, endtime, domaininfo;
         stream = stream)
 
-    eq, discretes, constants, info = create_interp_equation(
-        itp, "", t, t_ref, [x, y])
+    eq, discretes,
+    constants,
+    info = create_interp_equation(
+        itp, "", t, t_ref, [x, y];
+        spatial_interp = spatial_interp)
 
     vars = [eq.lhs]
 

--- a/src/regridding.jl
+++ b/src/regridding.jl
@@ -4,8 +4,9 @@ function get_polygons(d::DomainInfo{T}) where {T}
     # Use column-major (x-fastest) ordering to match vec() on data arrays
     polys = Vector{Vector{NTuple{2, T}}}(undef, nx*ny)
     for j in 1:ny, i in 1:nx
-        polys[(j-1)*nx + i] = [(x[i], y[j]), (x[i+1], y[j]), (x[i+1], y[j+1]),
-            (x[i], y[j+1]), (x[i], y[j])]
+
+        polys[(j - 1) * nx + i] = [(x[i], y[j]), (x[i + 1], y[j]), (x[i + 1], y[j + 1]),
+            (x[i], y[j + 1]), (x[i], y[j])]
     end
     return polys
 end
@@ -93,13 +94,17 @@ when interpolation is selected.
 function regridder(fs::FileSet, metadata::MetaData, domain::DomainInfo)
     if any(metadata.staggering) # Are any of the dimensions staggered?
         model_grid = EarthSciMLBase.grid(domain, metadata.staggering)
-        regrid! = (dst::AbstractArray, src::AbstractArray; extrapolate_type = Flat()) -> begin
+        regrid! = (dst::AbstractArray,
+            src::AbstractArray;
+            extrapolate_type = Flat()) -> begin
             interpolate_from!(dst, src, metadata, model_grid, domain;
                 extrapolate_type = extrapolate_type)
         end
     else
         regridder = horizontal_regridder(fs, metadata, domain)
-        regrid! = (dst::AbstractArray, src::AbstractArray; extrapolate_type = Flat()) -> begin
+        regrid! = (dst::AbstractArray,
+            src::AbstractArray;
+            extrapolate_type = Flat()) -> begin
             regrid_horizontal!(dst, regridder, src, metadata)
         end
     end

--- a/src/usgs3dep.jl
+++ b/src/usgs3dep.jl
@@ -306,6 +306,9 @@ Note that 3DEP coverage is limited to the United States
   - `name`: System name (default `:USGS3DEP`).
   - `resolution`: Target resolution in arc-seconds (default 1/3 ≈ 10m).
   - `stream`: Whether to stream data lazily (default `true`).
+  - `spatial_interp = :linear` (default) does full multilinear interpolation; `:nearest` does
+    spatial nearest-neighbour + time-only linear interpolation for ~8x speedup when queries
+    are always at grid points.
 
 # Example
 
@@ -321,7 +324,7 @@ elev = USGS3DEP(domain)
 ```
 """
 function USGS3DEP(domaininfo::DomainInfo; name = :USGS3DEP, resolution = 1 / 3,
-        stream = true)
+        stream = true, spatial_interp::Symbol = :linear)
     starttime, endtime = get_tspan_datetime(domaininfo)
     fs = USGS3DEPFileSet(domaininfo; resolution = resolution)
 
@@ -341,8 +344,10 @@ function USGS3DEP(domaininfo::DomainInfo; name = :USGS3DEP, resolution = 1 / 3,
 
     # Elevation equation.
     eq_elev, discretes_e,
-    constants_e, info_e = create_interp_equation(
-        elev_itp, "", t, t_ref, coords)
+    constants_e,
+    info_e = create_interp_equation(
+        elev_itp, "", t, t_ref, coords;
+        spatial_interp = spatial_interp)
     params = Any[t_ref]
     all_discretes = Any[discretes_e...]
     all_constants = Any[constants_e...]
@@ -356,8 +361,10 @@ function USGS3DEP(domaininfo::DomainInfo; name = :USGS3DEP, resolution = 1 / 3,
         slope_itp = DataSetInterpolator{dt}(
             slope_fs, string(component), starttime, endtime, domaininfo; stream = stream)
         eq_slope, discretes_s,
-        constants_s, info_s = create_interp_equation(
-            slope_itp, "", t, t_ref, coords)
+        constants_s,
+        info_s = create_interp_equation(
+            slope_itp, "", t, t_ref, coords;
+            spatial_interp = spatial_interp)
         push!(eqs, eq_slope)
         push!(lhs_vars, eq_slope.lhs)
         append!(all_discretes, discretes_s)

--- a/src/usgs3dep.jl
+++ b/src/usgs3dep.jl
@@ -2,7 +2,6 @@ export USGS3DEP, USGS3DEPCoupler
 
 const USGS3DEP_MIRROR = "https://elevation.nationalmap.gov/arcgis/rest/services/3DEPElevation/ImageServer"
 
-
 """
 $(SIGNATURES)
 
@@ -20,7 +19,7 @@ See https://elevation.nationalmap.gov/ for more information.
 """
 struct USGS3DEPFileSet <: FileSet
     mirror::String
-    bbox::NTuple{4,Float64}  # (west, south, east, north) in degrees
+    bbox::NTuple{4, Float64}  # (west, south, east, north) in degrees
     width::Int
     height::Int
     freq_info::DataFrequencyInfo
@@ -32,17 +31,19 @@ $(SIGNATURES)
 Create a USGS3DEPFileSet covering the spatial extent of the given domain.
 
 !!! warning "US coverage only"
+
     3DEP provides elevation data for the United States (CONUS, Alaska, Hawaii,
     and US territories). Requests for domains outside this coverage will return
     nodata values.
 
 # Arguments
-- `domaininfo`: A `DomainInfo` or `GridSpec` providing the spatial domain.
-- `resolution`: Target resolution in arc-seconds (default 1/3 ≈ 10m).
-  The pixel count is capped at 1000×1000 to avoid excessive download sizes
-  and API timeouts.
+
+  - `domaininfo`: A `DomainInfo` or `GridSpec` providing the spatial domain.
+  - `resolution`: Target resolution in arc-seconds (default 1/3 ≈ 10m).
+    The pixel count is capped at 1000×1000 to avoid excessive download sizes
+    and API timeouts.
 """
-function USGS3DEPFileSet(domaininfo; resolution=1 / 3)
+function USGS3DEPFileSet(domaininfo; resolution = 1 / 3)
     grid = _compute_grid(domaininfo, (false, false, false))
 
     # Convert domain grid coordinates to lon-lat degrees for the API request.
@@ -70,15 +71,19 @@ function USGS3DEPFileSet(domaininfo; resolution=1 / 3)
         # Also sample edges to capture curvature for large domains.
         for x in xs
             lo, la = to_lonlat(x, first(ys))
-            push!(lon_vals, rad2deg(lo)); push!(lat_vals, rad2deg(la))
+            push!(lon_vals, rad2deg(lo));
+            push!(lat_vals, rad2deg(la))
             lo, la = to_lonlat(x, last(ys))
-            push!(lon_vals, rad2deg(lo)); push!(lat_vals, rad2deg(la))
+            push!(lon_vals, rad2deg(lo));
+            push!(lat_vals, rad2deg(la))
         end
         for y in ys
             lo, la = to_lonlat(first(xs), y)
-            push!(lon_vals, rad2deg(lo)); push!(lat_vals, rad2deg(la))
+            push!(lon_vals, rad2deg(lo));
+            push!(lat_vals, rad2deg(la))
             lo, la = to_lonlat(last(xs), y)
-            push!(lon_vals, rad2deg(lo)); push!(lat_vals, rad2deg(la))
+            push!(lon_vals, rad2deg(lo));
+            push!(lat_vals, rad2deg(la))
         end
         lon_min, lon_max = extrema(lon_vals)
         lat_min, lat_max = extrema(lat_vals)
@@ -113,7 +118,7 @@ function relpath(fs::USGS3DEPFileSet, t::DateTime)
     "usgs3dep/elevation_$(w)_$(s)_$(e)_$(n)_$(fs.width)x$(fs.height).tif"
 end
 
-function url(fs::USGS3DEPFileSet, t::DateTime, varname=nothing)
+function url(fs::USGS3DEPFileSet, t::DateTime, varname = nothing)
     w, s, e, n = fs.bbox
     string(
         fs.mirror,
@@ -125,7 +130,7 @@ function url(fs::USGS3DEPFileSet, t::DateTime, varname=nothing)
         "&format=tiff",
         "&pixelType=F32",
         "&interpolation=+RSP_BilinearInterpolation",
-        "&f=image",
+        "&f=image"
     )
 end
 
@@ -154,7 +159,7 @@ function loadmetadata(fs::USGS3DEPFileSet, varname)::MetaData
         1,    # xdim (lon)
         2,    # ydim (lat)
         -1,   # zdim (none)
-        (false, false, false),
+        (false, false, false)
     )
 end
 
@@ -200,7 +205,7 @@ end
 
 mirror(fs::USGS3DEPSlopeFileSet) = mirror(fs.parent)
 relpath(fs::USGS3DEPSlopeFileSet, t::DateTime) = relpath(fs.parent, t)
-url(fs::USGS3DEPSlopeFileSet, t::DateTime, varname=nothing) = url(fs.parent, t, varname)
+url(fs::USGS3DEPSlopeFileSet, t::DateTime, varname = nothing) = url(fs.parent, t, varname)
 DataFrequencyInfo(fs::USGS3DEPSlopeFileSet)::DataFrequencyInfo = DataFrequencyInfo(fs.parent)
 varnames(fs::USGS3DEPSlopeFileSet) = [string(fs.component)]
 
@@ -212,7 +217,7 @@ function loadmetadata(fs::USGS3DEPSlopeFileSet, varname)::MetaData
     MetaData(
         elev_md.coords, "1", desc,
         elev_md.dimnames, elev_md.varsize, elev_md.native_sr,
-        elev_md.xdim, elev_md.ydim, elev_md.zdim, elev_md.staggering,
+        elev_md.xdim, elev_md.ydim, elev_md.zdim, elev_md.staggering
     )
 end
 
@@ -278,9 +283,10 @@ Create a ModelingToolkit `System` that provides terrain elevation and slope data
 from the USGS 3D Elevation Program (3DEP).
 
 The system exposes three variables interpolated to the simulation coordinates:
-- `elevation` (m): terrain elevation above sea level
-- `dzdx` (dimensionless): terrain slope in the x (east) direction (rise/run)
-- `dzdy` (dimensionless): terrain slope in the y (north) direction (rise/run)
+
+  - `elevation` (m): terrain elevation above sea level
+  - `dzdx` (dimensionless): terrain slope in the x (east) direction (rise/run)
+  - `dzdy` (dimensionless): terrain slope in the y (north) direction (rise/run)
 
 Slopes are computed from the elevation grid using central finite differences
 with coordinate conversion from lon/lat to metric distances.
@@ -295,27 +301,29 @@ Note that 3DEP coverage is limited to the United States
 (CONUS, Alaska, Hawaii, and US territories).
 
 # Arguments
-- `domaininfo`: A `DomainInfo` specifying the spatial and temporal domain.
-- `name`: System name (default `:USGS3DEP`).
-- `resolution`: Target resolution in arc-seconds (default 1/3 ≈ 10m).
-- `stream`: Whether to stream data lazily (default `true`).
+
+  - `domaininfo`: A `DomainInfo` specifying the spatial and temporal domain.
+  - `name`: System name (default `:USGS3DEP`).
+  - `resolution`: Target resolution in arc-seconds (default 1/3 ≈ 10m).
+  - `stream`: Whether to stream data lazily (default `true`).
 
 # Example
+
 ```julia
 using EarthSciData, EarthSciMLBase, ModelingToolkit, Dates
 domain = DomainInfo(
     DateTime(2018, 11, 8), DateTime(2018, 11, 9);
     lonrange = deg2rad(-121.7):deg2rad(0.01):deg2rad(-121.5),
     latrange = deg2rad(39.7):deg2rad(0.01):deg2rad(39.8),
-    levrange = 1:1,
+    levrange = 1:1
 )
 elev = USGS3DEP(domain)
 ```
 """
-function USGS3DEP(domaininfo::DomainInfo; name=:USGS3DEP, resolution=1 / 3,
-        stream=true)
+function USGS3DEP(domaininfo::DomainInfo; name = :USGS3DEP, resolution = 1 / 3,
+        stream = true)
     starttime, endtime = get_tspan_datetime(domaininfo)
-    fs = USGS3DEPFileSet(domaininfo; resolution=resolution)
+    fs = USGS3DEPFileSet(domaininfo; resolution = resolution)
 
     @parameters t_ref = get_tref(domaininfo) [unit = u"s", description = "Reference time"]
     pvs = EarthSciMLBase.pvars(domaininfo)
@@ -327,17 +335,18 @@ function USGS3DEP(domaininfo::DomainInfo; name=:USGS3DEP, resolution=1 / 3,
     # may use x/y (projected CRS). Map domain coordinate names to the data
     # dimension names so the interpolator can apply coord_trans automatically.
     elev_itp = DataSetInterpolator{dt}(
-        fs, "elevation", starttime, endtime, domaininfo; stream=stream)
+        fs, "elevation", starttime, endtime, domaininfo; stream = stream)
     dims = dimnames(elev_itp)  # ["lon", "lat"] from the data metadata
     coords = _match_domain_coords(dims, pvdict, pvs)
 
     # Elevation equation.
-    eq_elev, discretes_e, constants_e, info_e = create_interp_equation(
+    eq_elev, discretes_e,
+    constants_e, info_e = create_interp_equation(
         elev_itp, "", t, t_ref, coords)
     params = Any[t_ref]
     all_discretes = Any[discretes_e...]
     all_constants = Any[constants_e...]
-    interp_infos = [info_e]
+    interp_infos = Any[info_e]
     lhs_vars = Num[eq_elev.lhs]
     eqs = Equation[eq_elev]
 
@@ -345,8 +354,9 @@ function USGS3DEP(domaininfo::DomainInfo; name=:USGS3DEP, resolution=1 / 3,
     for component in (:dzdx, :dzdy)
         slope_fs = USGS3DEPSlopeFileSet(fs, component)
         slope_itp = DataSetInterpolator{dt}(
-            slope_fs, string(component), starttime, endtime, domaininfo; stream=stream)
-        eq_slope, discretes_s, constants_s, info_s = create_interp_equation(
+            slope_fs, string(component), starttime, endtime, domaininfo; stream = stream)
+        eq_slope, discretes_s,
+        constants_s, info_s = create_interp_equation(
             slope_itp, "", t, t_ref, coords)
         push!(eqs, eq_slope)
         push!(lhs_vars, eq_slope.lhs)
@@ -358,13 +368,13 @@ function USGS3DEP(domaininfo::DomainInfo; name=:USGS3DEP, resolution=1 / 3,
     all_params = Any[t_ref, all_constants..., all_discretes...]
     sys = System(
         eqs, t, lhs_vars, all_params;
-        name=name,
-        initial_conditions=_itp_defaults(all_params),
+        name = name,
+        initial_conditions = _itp_defaults(all_params),
         discrete_events = [build_interp_event(interp_infos, starttime)],
-        metadata=Dict(
+        metadata = Dict(
             CoupleType => USGS3DEPCoupler,
-            SysDomainInfo => domaininfo,
-        ),
+            SysDomainInfo => domaininfo
+        )
     )
     return sys
 end

--- a/src/usgs3dep.jl
+++ b/src/usgs3dep.jl
@@ -312,7 +312,8 @@ domain = DomainInfo(
 elev = USGS3DEP(domain)
 ```
 """
-function USGS3DEP(domaininfo::DomainInfo; name=:USGS3DEP, resolution=1 / 3, stream=true)
+function USGS3DEP(domaininfo::DomainInfo; name=:USGS3DEP, resolution=1 / 3,
+        stream=true)
     starttime, endtime = get_tspan_datetime(domaininfo)
     fs = USGS3DEPFileSet(domaininfo; resolution=resolution)
 
@@ -331,9 +332,13 @@ function USGS3DEP(domaininfo::DomainInfo; name=:USGS3DEP, resolution=1 / 3, stre
     coords = _match_domain_coords(dims, pvdict, pvs)
 
     # Elevation equation.
-    eq_elev, p_elev = create_interp_equation(elev_itp, "", t, t_ref, coords)
-    params = Any[t_ref, p_elev]
-    vars = Num[eq_elev.lhs]
+    eq_elev, discretes_e, constants_e, info_e = create_interp_equation(
+        elev_itp, "", t, t_ref, coords)
+    params = Any[t_ref]
+    all_discretes = Any[discretes_e...]
+    all_constants = Any[constants_e...]
+    interp_infos = [info_e]
+    lhs_vars = Num[eq_elev.lhs]
     eqs = Equation[eq_elev]
 
     # Slope equations (dzdx and dzdy).
@@ -341,19 +346,23 @@ function USGS3DEP(domaininfo::DomainInfo; name=:USGS3DEP, resolution=1 / 3, stre
         slope_fs = USGS3DEPSlopeFileSet(fs, component)
         slope_itp = DataSetInterpolator{dt}(
             slope_fs, string(component), starttime, endtime, domaininfo; stream=stream)
-        eq_slope, p_slope = create_interp_equation(slope_itp, "", t, t_ref, coords)
+        eq_slope, discretes_s, constants_s, info_s = create_interp_equation(
+            slope_itp, "", t, t_ref, coords)
         push!(eqs, eq_slope)
-        push!(vars, eq_slope.lhs)
-        push!(params, p_slope)
+        push!(lhs_vars, eq_slope.lhs)
+        append!(all_discretes, discretes_s)
+        append!(all_constants, constants_s)
+        push!(interp_infos, info_s)
     end
 
+    all_params = Any[t_ref, all_constants..., all_discretes...]
     sys = System(
-        eqs, t, vars, params;
+        eqs, t, lhs_vars, all_params;
         name=name,
-        initial_conditions=_itp_defaults(params),
+        initial_conditions=_itp_defaults(all_params),
+        discrete_events = [build_interp_event(interp_infos, starttime)],
         metadata=Dict(
             CoupleType => USGS3DEPCoupler,
-            SysDiscreteEvent => create_updater_sys_event(name, params, starttime),
             SysDomainInfo => domaininfo,
         ),
     )

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -43,7 +43,7 @@ const _UNIT_MAP = Dict(
     "s-1" => (1, u"s^-1"),
     "K m2 kg-1 s-1" => (1, u"K*m^2/kg/s"),
     "%" => (0.01, Quantity(1.0)),
-    "(0 - 1)" => (1, Quantity(1.0)),
+    "(0 - 1)" => (1, Quantity(1.0))
 )
 
 function to_unit(u)

--- a/src/wrf.jl
+++ b/src/wrf.jl
@@ -162,7 +162,10 @@ function WRF(domaininfo::DomainInfo; name = :WRF, stream = true)
     @parameters t_ref=get_tref(domaininfo) [unit = u"s", description = "Reference time"]
     eqs = Equation[]
     params = Any[t_ref]
-    vars = Num[]
+    all_discretes = Any[]
+    all_constants = Any[]
+    interp_infos = []
+    lhs_vars = Num[]
 
     xdim = :x in keys(pvdict) ? :x : :lon
     ydim = :y in keys(pvdict) ? :y : :lat
@@ -198,14 +201,17 @@ function WRF(domaininfo::DomainInfo; name = :WRF, stream = true)
             @assert translated_dim ∈ keys(pvdict) "Dimension $d (translated to $translated_dim) is not in the domaininfo coordinates ($(pvs))."
             push!(coords, pvdict[translated_dim])
         end
-        eq, param = create_interp_equation(itp, "", t, t_ref, coords)
+        eq, discretes, constants, info = create_interp_equation(
+            itp, "", t, t_ref, coords)
         push!(eqs, eq)
-        push!(params, param)
-        push!(vars, eq.lhs)
+        append!(all_discretes, discretes)
+        append!(all_constants, constants)
+        push!(interp_infos, info)
+        push!(lhs_vars, eq.lhs)
         if varname ∈ ["PH", "PHB"]
             # Special handling for PH and PHB to calculate the total pressure
             # as they are needed for geopotential height calculation.
-            z_params[varname] = param
+            z_params[varname] = info
             z_params[varname * "_coords"] = coords
         end
     end
@@ -216,7 +222,7 @@ function WRF(domaininfo::DomainInfo; name = :WRF, stream = true)
     PB = eqs[findfirst(x -> EarthSciMLBase.var2symbol(x.lhs) == :PB, eqs)].rhs
     pressure_eq = P_total ~ P + PB
     push!(eqs, pressure_eq)
-    push!(vars, P_total)
+    push!(lhs_vars, P_total)
 
     # Horizontal coordinate transforms
     if :lat in keys(pvdict)
@@ -233,7 +239,7 @@ function WRF(domaininfo::DomainInfo; name = :WRF, stream = true)
         lon_trans = δxδlon ~ lon2m * cos(pvdict[:lat])
         lat_trans = δyδlat ~ lat2meters
         push!(eqs, lon_trans, lat_trans)
-        push!(vars, δxδlon, δyδlat)
+        push!(lhs_vars, δxδlon, δyδlat)
         push!(params, lon2m, lat2meters)
     end
 
@@ -244,7 +250,7 @@ function WRF(domaininfo::DomainInfo; name = :WRF, stream = true)
     @constants g=9.80665 [unit = u"m/s^2", description = "Acceleration due to gravity"]
     z_expr = (PH + PHB) / g
     push!(eqs, z ~ z_expr)
-    push!(vars, z)
+    push!(lhs_vars, z)
     push!(params, g)
 
     # Height per level
@@ -252,22 +258,25 @@ function WRF(domaininfo::DomainInfo; name = :WRF, stream = true)
         unit = u"m",
         description = "Height derivative with respect to vertical level"
     ]
-    ph = z_params["PH"]
-    phb = z_params["PHB"]
+    ph_info = z_params["PH"]
+    phb_info = z_params["PHB"]
     phc = z_params["PH_coords"]
     phbc = z_params["PHB_coords"]
-    Δph = ph(t + t_ref, phc[1], phc[2], phc[3] + 1) - ph(t + t_ref, phc...)
-    Δphb = phb(t + t_ref, phbc[1], phbc[2], phbc[3] + 1) - phb(t + t_ref, phbc...)
+    Δph = build_interp_expr(ph_info, t + t_ref, [phc[1], phc[2], phc[3] + 1]) -
+          build_interp_expr(ph_info, t + t_ref, phc)
+    Δphb = build_interp_expr(phb_info, t + t_ref, [phbc[1], phbc[2], phbc[3] + 1]) -
+           build_interp_expr(phb_info, t + t_ref, phbc)
     lev_trans = δzδlev ~ (Δph + Δphb) / g
     push!(eqs, lev_trans)
-    push!(vars, δzδlev)
+    push!(lhs_vars, δzδlev)
 
-    all_params = [pvdict[xdim], pvdict[ydim], pvdict[:lev], params...]
-    sys = System(eqs, t, vars, all_params;
+    all_params = [pvdict[xdim], pvdict[ydim], pvdict[:lev],
+        all_constants..., all_discretes..., params...]
+    sys = System(eqs, t, lhs_vars, all_params;
         name = name,
         initial_conditions = _itp_defaults(all_params),
+        discrete_events = [build_interp_event(interp_infos, starttime)],
         metadata = Dict(CoupleType => WRFCoupler,
-            SysDiscreteEvent => create_updater_sys_event(name, params, starttime),
             SysDomainInfo => domaininfo)
     )
     return sys

--- a/src/wrf.jl
+++ b/src/wrf.jl
@@ -146,7 +146,10 @@ function varnames(fs::WRFFileSet)
     end
 end
 
-Base.close(fs::WRFFileSet) = lock(nclock) do; close(fs.ds); end
+Base.close(fs::WRFFileSet) =
+    lock(nclock) do ;
+        close(fs.ds);
+    end
 
 struct WRFCoupler
     sys::Any

--- a/src/wrf.jl
+++ b/src/wrf.jl
@@ -155,7 +155,19 @@ struct WRFCoupler
     sys::Any
 end
 
-function WRF(domaininfo::DomainInfo; name = :WRF, stream = true)
+"""
+$(SIGNATURES)
+
+A data loader for WRF output data.
+
+`stream` specifies whether the data should be streamed in as needed or loaded all at once.
+
+`spatial_interp = :linear` (default) does full multilinear interpolation; `:nearest` does
+spatial nearest-neighbour + time-only linear interpolation for ~8x speedup when queries
+are always at grid points.
+"""
+function WRF(domaininfo::DomainInfo; name = :WRF, stream = true,
+        spatial_interp::Symbol = :linear)
     starttime, endtime = get_tspan_datetime(domaininfo)
     fs = WRFFileSet("https://data.rda.ucar.edu/d340000/", domaininfo)
 
@@ -204,8 +216,11 @@ function WRF(domaininfo::DomainInfo; name = :WRF, stream = true)
             @assert translated_dim ∈ keys(pvdict) "Dimension $d (translated to $translated_dim) is not in the domaininfo coordinates ($(pvs))."
             push!(coords, pvdict[translated_dim])
         end
-        eq, discretes, constants, info = create_interp_equation(
-            itp, "", t, t_ref, coords)
+        eq, discretes,
+        constants,
+        info = create_interp_equation(
+            itp, "", t, t_ref, coords;
+            spatial_interp = spatial_interp)
         push!(eqs, eq)
         append!(all_discretes, discretes)
         append!(all_constants, constants)

--- a/test/NCEP-NCAR_Reanalysis_test.jl
+++ b/test/NCEP-NCAR_Reanalysis_test.jl
@@ -98,11 +98,11 @@ end
         "NCEPNCARReanalysis₊air(t, lon, lat, lev)",
         "NCEPNCARReanalysis₊omega(t, lon, lat, lev)",
         "NCEPNCARReanalysis₊hgt(t, lon, lat, lev)",
-        "NCEPNCARReanalysis₊uwnd_itp(NCEPNCARReanalysis₊t_ref + t, lon, lat, lev)",
-        "NCEPNCARReanalysis₊vwnd_itp(NCEPNCARReanalysis₊t_ref + t, lon, lat, lev)",
-        "NCEPNCARReanalysis₊air_itp(NCEPNCARReanalysis₊t_ref + t, lon, lat, lev)",
-        "NCEPNCARReanalysis₊omega_itp(NCEPNCARReanalysis₊t_ref + t, lon, lat, lev)",
-        "NCEPNCARReanalysis₊hgt_itp(NCEPNCARReanalysis₊t_ref + t, lon, lat, lev)",
+        "interp_unsafe(NCEPNCARReanalysis₊uwnd_data",
+        "interp_unsafe(NCEPNCARReanalysis₊vwnd_data",
+        "interp_unsafe(NCEPNCARReanalysis₊air_data",
+        "interp_unsafe(NCEPNCARReanalysis₊omega_data",
+        "interp_unsafe(NCEPNCARReanalysis₊hgt_data",
         "lon2m",
         "lat2meters",
         "Differential(lat, 1)(ExampleSys₊c(t, lon, lat, lev))",
@@ -124,19 +124,25 @@ end
 end
 
 @testsnippet NCEPProb begin
+    using ModelingToolkit: t, D
     using SymbolicIndexingInterface: setp, getsym, parameter_values
     using SciMLBase: ODEProblem
-    ncep_sys = mtkcompile(ncep_sys)
-    prob = ODEProblem(ncep_sys, [], (24.0 * 3600, 48.0 * 3600))
-    setter = setp(ncep_sys, [:lon, :lat, :lev])
-    ps = parameter_values(prob)
+    using OrdinaryDiffEqTsit5
+
+    # Wrap with a dummy state variable so init/solve work.
+    @variables _dummy(t) = 0.0
+    _sys = compose(System([D(_dummy) ~ 0], t; name = :_w), ncep_sys)
+    compiled = mtkcompile(_sys)
+    prob = ODEProblem(compiled, [], (24.0 * 3600, 48.0 * 3600))
+    integ = init(prob, Tsit5())
+    setter = setp(integ, [compiled.NCEPNCARReanalysis.lon, compiled.NCEPNCARReanalysis.lat, compiled.NCEPNCARReanalysis.lev])
 end
 
 @testitem "ncep vertical velocity wwnd" setup=[NCEPSetup, NCEPProb] begin
-    f = getsym(prob, :wwnd)
+    f = getsym(integ, compiled.NCEPNCARReanalysis.wwnd)
     W_val = map([1, 2, 5, 7.5, 12, 16]) do lev
-        setter(prob, [lonv, latv, lev])
-        f(prob)
+        setter(integ, [lonv, latv, lev])
+        f(integ)
     end
     W_val_want = [0.0019118377540854117, 0.0016255623000058477, -0.015113770574739198,
         -0.002477431693133608, 0.015227246265886294, -0.0]
@@ -144,20 +150,20 @@ end
 end
 
 @testitem "ncep pressure" setup=[NCEPSetup, NCEPProb] begin
-    f = getsym(prob, :p)
+    f = getsym(integ, compiled.NCEPNCARReanalysis.p)
     p_vals = map([1, 2, 5, 7.5, 12, 16]) do lev
-        setter(prob, [lonv, latv, lev])
-        f(prob)
+        setter(integ, [lonv, latv, lev])
+        f(integ)
     end
     p_want = [100000, 92500, 60000, 35000, 10000, 2000]
     @test p_vals≈p_want rtol=1e-2
 end
 
 @testitem "ncep δzδlev" setup=[NCEPSetup, NCEPProb] begin
-    f = getsym(prob, :δzδlev)
+    f = getsym(integ, compiled.NCEPNCARReanalysis.δzδlev)
     δzδlev_vals = map([1, 2, 5, 7.5, 12, 16]) do lev
-        setter(prob, [lonv, latv, lev])
-        f(prob)
+        setter(integ, [lonv, latv, lev])
+        f(integ)
     end
     δzδlev_want = [598, 649, 1358, 1583, 2232, 4410]
     @test δzδlev_vals≈δzδlev_want rtol=1e-3
@@ -165,10 +171,10 @@ end
 
 
 @testitem "ncep ground level vertical velocity" setup=[NCEPSetup, NCEPProb] begin
-    f = getsym(prob, :omega)
+    f = getsym(integ, compiled.NCEPNCARReanalysis.omega)
     omega_vals = map([0.5, 1]) do lev
-        setter(prob, [lonv, latv, lev])
-        f(prob)
+        setter(integ, [lonv, latv, lev])
+        f(integ)
     end
     omega_want = [0.0, -0.024750000797212124]
     @test omega_vals≈omega_want

--- a/test/NCEP-NCAR_Reanalysis_test.jl
+++ b/test/NCEP-NCAR_Reanalysis_test.jl
@@ -135,7 +135,9 @@ end
     compiled = mtkcompile(_sys)
     prob = ODEProblem(compiled, [], (24.0 * 3600, 48.0 * 3600))
     integ = init(prob, Tsit5())
-    setter = setp(integ, [compiled.NCEPNCARReanalysis.lon, compiled.NCEPNCARReanalysis.lat, compiled.NCEPNCARReanalysis.lev])
+    setter = setp(integ,
+        [compiled.NCEPNCARReanalysis.lon, compiled.NCEPNCARReanalysis.lat,
+            compiled.NCEPNCARReanalysis.lev])
 end
 
 @testitem "ncep vertical velocity wwnd" setup=[NCEPSetup, NCEPProb] begin
@@ -168,7 +170,6 @@ end
     δzδlev_want = [598, 649, 1358, 1583, 2232, 4410]
     @test δzδlev_vals≈δzδlev_want rtol=1e-3
 end
-
 
 @testitem "ncep ground level vertical velocity" setup=[NCEPSetup, NCEPProb] begin
     f = getsym(integ, compiled.NCEPNCARReanalysis.omega)

--- a/test/ceds_test.jl
+++ b/test/ceds_test.jl
@@ -8,7 +8,7 @@
         DateTime(2016, 5, 2);
         latrange = deg2rad(-85.0f0):deg2rad(2):deg2rad(85.0f0),
         lonrange = deg2rad(-180.0f0):deg2rad(2.5):deg2rad(175.0f0),
-        levrange = 1:10,
+        levrange = 1:10
     )
     lon, lat, lev = EarthSciMLBase.pvars(domain)
 
@@ -79,17 +79,20 @@ end
 
     # All sectors summed.
     fs_all = EarthSciData.CEDSFileSet("SO2", ts, te)
-    itp_all = EarthSciData.DataSetInterpolator{Float32}(fs_all, "SO2_em_anthro", ts, te, domain)
+    itp_all = EarthSciData.DataSetInterpolator{Float32}(
+        fs_all, "SO2_em_anthro", ts, te, domain)
     val_all = interp(itp_all, ts, deg2rad(116.0f0), deg2rad(39.0f0))
 
     # Energy sector only (index 1).
     fs_energy = EarthSciData.CEDSFileSet("SO2", ts, te; sectors = [1])
-    itp_energy = EarthSciData.DataSetInterpolator{Float32}(fs_energy, "SO2_em_anthro", ts, te, domain)
+    itp_energy = EarthSciData.DataSetInterpolator{Float32}(
+        fs_energy, "SO2_em_anthro", ts, te, domain)
     val_energy = interp(itp_energy, ts, deg2rad(116.0f0), deg2rad(39.0f0))
 
     # Energy + Industrial sectors (indices 1, 2).
     fs_multi = EarthSciData.CEDSFileSet("SO2", ts, te; sectors = [1, 2])
-    itp_multi = EarthSciData.DataSetInterpolator{Float32}(fs_multi, "SO2_em_anthro", ts, te, domain)
+    itp_multi = EarthSciData.DataSetInterpolator{Float32}(
+        fs_multi, "SO2_em_anthro", ts, te, domain)
     val_multi = interp(itp_multi, ts, deg2rad(116.0f0), deg2rad(39.0f0))
 
     # Single sector should be <= multi-sector <= total.
@@ -129,7 +132,8 @@ end
 
     # Multiple species should return independent, non-identical values at the same location.
     fs_co = EarthSciData.CEDSFileSet("CO", ts, te)
-    itp_co = EarthSciData.DataSetInterpolator{Float32}(fs_co, "CO_em_anthro", ts, te, domain)
+    itp_co = EarthSciData.DataSetInterpolator{Float32}(
+        fs_co, "CO_em_anthro", ts, te, domain)
     val_co = interp(itp_co, ts, deg2rad(116.0f0), deg2rad(39.0f0))
     @test val_co > 0.0f0
     @test val_co != val_china  # Different species should have different values
@@ -216,7 +220,7 @@ end
     prob = ODEProblem(
         sys,
         [lat_p => deg2rad(40.0), lon_p => deg2rad(116.0)],
-        (0.0, 60.0),
+        (0.0, 60.0)
     )
     sol = solve(prob, Tsit5())
     @test length(sol.t) > 1

--- a/test/ceds_test.jl
+++ b/test/ceds_test.jl
@@ -65,11 +65,11 @@ end
     itp = EarthSciData.DataSetInterpolator{Float32}(fs, "SO2_em_anthro", ts, te, domain)
 
     # Test interpolation at a point in eastern China (known high SO2 area).
-    result = interp(itp, ts, deg2rad(116.0f0), deg2rad(39.0f0))
+    result = interp!(itp, ts, deg2rad(116.0f0), deg2rad(39.0f0))
     @test result > 0.0f0  # Should be positive emissions.
 
     # Test interpolation in the middle of the Pacific (should be very small).
-    result_ocean = interp(itp, ts, deg2rad(-170.0f0), deg2rad(0.0f0))
+    result_ocean = interp!(itp, ts, deg2rad(-170.0f0), deg2rad(0.0f0))
     @test result_ocean >= 0.0f0
     @test result_ocean < result  # Much less than eastern China.
 end
@@ -81,19 +81,19 @@ end
     fs_all = EarthSciData.CEDSFileSet("SO2", ts, te)
     itp_all = EarthSciData.DataSetInterpolator{Float32}(
         fs_all, "SO2_em_anthro", ts, te, domain)
-    val_all = interp(itp_all, ts, deg2rad(116.0f0), deg2rad(39.0f0))
+    val_all = interp!(itp_all, ts, deg2rad(116.0f0), deg2rad(39.0f0))
 
     # Energy sector only (index 1).
     fs_energy = EarthSciData.CEDSFileSet("SO2", ts, te; sectors = [1])
     itp_energy = EarthSciData.DataSetInterpolator{Float32}(
         fs_energy, "SO2_em_anthro", ts, te, domain)
-    val_energy = interp(itp_energy, ts, deg2rad(116.0f0), deg2rad(39.0f0))
+    val_energy = interp!(itp_energy, ts, deg2rad(116.0f0), deg2rad(39.0f0))
 
     # Energy + Industrial sectors (indices 1, 2).
     fs_multi = EarthSciData.CEDSFileSet("SO2", ts, te; sectors = [1, 2])
     itp_multi = EarthSciData.DataSetInterpolator{Float32}(
         fs_multi, "SO2_em_anthro", ts, te, domain)
-    val_multi = interp(itp_multi, ts, deg2rad(116.0f0), deg2rad(39.0f0))
+    val_multi = interp!(itp_multi, ts, deg2rad(116.0f0), deg2rad(39.0f0))
 
     # Single sector should be <= multi-sector <= total.
     @test val_energy <= val_multi || val_energy ≈ val_multi
@@ -121,12 +121,12 @@ end
 
     # Pin a quantitative value at a known high-emission location (eastern China).
     # SO2 emissions from power plants and industry in this region are well-documented.
-    val_china = interp(itp, ts, deg2rad(116.0f0), deg2rad(39.0f0))
+    val_china = interp!(itp, ts, deg2rad(116.0f0), deg2rad(39.0f0))
     @test val_china > 1.0f-12  # Should be a meaningful positive flux (kg/m²/s)
     @test val_china < 1.0f-6   # But not unreasonably large
 
     # Middle of the Sahara desert - should have very low SO2 emissions.
-    val_sahara = interp(itp, ts, deg2rad(10.0f0), deg2rad(25.0f0))
+    val_sahara = interp!(itp, ts, deg2rad(10.0f0), deg2rad(25.0f0))
     @test val_sahara >= 0.0f0
     @test val_sahara < val_china * 0.01f0  # Orders of magnitude less than China
 
@@ -134,7 +134,7 @@ end
     fs_co = EarthSciData.CEDSFileSet("CO", ts, te)
     itp_co = EarthSciData.DataSetInterpolator{Float32}(
         fs_co, "CO_em_anthro", ts, te, domain)
-    val_co = interp(itp_co, ts, deg2rad(116.0f0), deg2rad(39.0f0))
+    val_co = interp!(itp_co, ts, deg2rad(116.0f0), deg2rad(39.0f0))
     @test val_co > 0.0f0
     @test val_co != val_china  # Different species should have different values
 end
@@ -159,8 +159,8 @@ end
 
     # Continental US (high emissions) vs middle of Pacific (low emissions) -
     # if wrapping were wrong, these could be swapped.
-    val_us = interp(itp, ts, deg2rad(-90.0f0), deg2rad(35.0f0))
-    val_pacific = interp(itp, ts, deg2rad(170.0f0), deg2rad(35.0f0))
+    val_us = interp!(itp, ts, deg2rad(-90.0f0), deg2rad(35.0f0))
+    val_pacific = interp!(itp, ts, deg2rad(170.0f0), deg2rad(35.0f0))
     @test val_us > val_pacific  # US should have more SO2 than open Pacific
 end
 
@@ -234,7 +234,7 @@ end
     # approximately rate * time.
     fs = EarthSciData.CEDSFileSet("SO2", ts, te)
     itp = EarthSciData.DataSetInterpolator{Float32}(fs, "SO2_em_anthro", ts, te, domain)
-    rate = interp(itp, ts, deg2rad(116.0f0), deg2rad(40.0f0))
+    rate = interp!(itp, ts, deg2rad(116.0f0), deg2rad(40.0f0))
     expected_approx = Float64(rate) * 60.0
     @test sol.u[end][1] ≈ expected_approx rtol=0.1
 end

--- a/test/coupling_test.jl
+++ b/test/coupling_test.jl
@@ -13,22 +13,22 @@
     plev_vals = Float64.([1000, 975, 950, 925])
 
     era5_vars = Dict(
-        "t"  => ("K",          "Temperature",           260.0, 300.0),
-        "u"  => ("m s**-1",    "U component of wind",   -15.0, 15.0),
-        "v"  => ("m s**-1",    "V component of wind",   -15.0, 15.0),
-        "w"  => ("Pa s**-1",   "Vertical velocity",     -1.0,  1.0),
-        "q"  => ("kg kg**-1",  "Specific humidity",      0.0,   0.02),
-        "r"  => ("%",          "Relative humidity",       0.0,   100.0),
-        "z"  => ("m**2 s**-2", "Geopotential",           0.0,   1e5),
-        "d"  => ("s**-1",      "Divergence",             -1e-5, 1e-5),
-        "vo" => ("s**-1",      "Vorticity (relative)",   -1e-5, 1e-5),
-        "o3" => ("kg kg**-1",  "Ozone mass mixing ratio", 0.0,  1e-5),
-        "cc" => ("(0 - 1)",    "Fraction of cloud cover", 0.0,  1.0),
-        "ciwc" => ("kg kg**-1","Specific cloud ice water content",  0.0, 1e-5),
-        "clwc" => ("kg kg**-1","Specific cloud liquid water content",0.0,1e-5),
-        "crwc" => ("kg kg**-1","Specific rain water content",       0.0, 1e-5),
-        "cswc" => ("kg kg**-1","Specific snow water content",       0.0, 1e-5),
-        "pv"   => ("K m**2 kg**-1 s**-1","Potential vorticity",    -1e-5, 1e-5),
+        "t" => ("K", "Temperature", 260.0, 300.0),
+        "u" => ("m s**-1", "U component of wind", -15.0, 15.0),
+        "v" => ("m s**-1", "V component of wind", -15.0, 15.0),
+        "w" => ("Pa s**-1", "Vertical velocity", -1.0, 1.0),
+        "q" => ("kg kg**-1", "Specific humidity", 0.0, 0.02),
+        "r" => ("%", "Relative humidity", 0.0, 100.0),
+        "z" => ("m**2 s**-2", "Geopotential", 0.0, 1e5),
+        "d" => ("s**-1", "Divergence", -1e-5, 1e-5),
+        "vo" => ("s**-1", "Vorticity (relative)", -1e-5, 1e-5),
+        "o3" => ("kg kg**-1", "Ozone mass mixing ratio", 0.0, 1e-5),
+        "cc" => ("(0 - 1)", "Fraction of cloud cover", 0.0, 1.0),
+        "ciwc" => ("kg kg**-1", "Specific cloud ice water content", 0.0, 1e-5),
+        "clwc" => ("kg kg**-1", "Specific cloud liquid water content", 0.0, 1e-5),
+        "crwc" => ("kg kg**-1", "Specific rain water content", 0.0, 1e-5),
+        "cswc" => ("kg kg**-1", "Specific snow water content", 0.0, 1e-5),
+        "pv" => ("K m**2 kg**-1 s**-1", "Potential vorticity", -1e-5, 1e-5)
     )
 
     nlon = length(lon_vals)
@@ -42,6 +42,7 @@
 
         time_vals = DateTime[]
         for d in 1:Dates.daysinmonth(yr, mo), h in 0:6:18
+
             push!(time_vals, DateTime(yr, mo, d, h))
         end
         ntime = length(time_vals)
@@ -58,7 +59,7 @@
 
             nctime = defVar(ds, "valid_time", Float64, ("valid_time",),
                 attrib = Dict("units" => "hours since 1900-01-01 00:00:00",
-                              "calendar" => "proleptic_gregorian"))
+                    "calendar" => "proleptic_gregorian"))
             nctime[:] = time_vals
 
             for (varname, (unit_str, long_name, vmin, vmax)) in era5_vars
@@ -82,20 +83,20 @@
         DateTime(2020, 7, 1);
         latrange = deg2rad(40.0f0):deg2rad(2):deg2rad(60.0f0),
         lonrange = deg2rad(-10.0f0):deg2rad(2.5):deg2rad(30.0f0),
-        levrange = 1:4,
+        levrange = 1:4
     )
 end
 
 @testitem "EDGAR + ERA5 coupling" setup=[CouplingSetup] tags=[:coupling] begin
     using ModelingToolkit
 
-    emis = EDGARv81MonthlyEmis("NOx", "POWER_INDUSTRY", coupling_domain)
-    era5 = ERA5(coupling_domain; mirror=era5_coupling_mirror)
+    emis=EDGARv81MonthlyEmis("NOx", "POWER_INDUSTRY", coupling_domain)
+    era5=ERA5(coupling_domain; mirror = era5_coupling_mirror)
 
-    csys = couple(emis, era5)
-    sys = convert(System, csys)
-    eqs = observed(sys)
-    eqs_str = string(eqs)
+    csys=couple(emis, era5)
+    sys=convert(System, csys)
+    eqs=observed(sys)
+    eqs_str=string(eqs)
 
     # Coupling should connect lat, lon, lev from emissions to ERA5.
     @test occursin("EDGARv81MonthlyEmis₊lat(t) ~ ERA5₊lat", eqs_str)

--- a/test/edgar_v81_monthly_test.jl
+++ b/test/edgar_v81_monthly_test.jl
@@ -50,7 +50,7 @@ end
 
     itp=EarthSciData.DataSetInterpolator{Float32}(fileset, varname, ts, te, domain)
     # Central Germany (high power plant density)
-    result=EarthSciData.interp(itp, sample_time, deg2rad(10.0f0), deg2rad(51.0f0))
+    result=EarthSciData.interp!(itp, sample_time, deg2rad(10.0f0), deg2rad(51.0f0))
     @test result >= 0.0f0
 end
 

--- a/test/edgar_v81_monthly_test.jl
+++ b/test/edgar_v81_monthly_test.jl
@@ -20,17 +20,17 @@ end
 
 @testitem "EDGAR Basics" setup=[EDGARSetup] tags=[:edgar] begin
     using ModelingToolkit: equations
-    eqs = equations(emis)
+    eqs=equations(emis)
     @test length(eqs) >= 1
     @test contains(string(eqs[1].rhs), "Δz")
 end
 
 @testitem "EDGAR Metadata" setup=[EDGARSetup] tags=[:edgar] begin
-    vnames = EarthSciData.varnames(fileset)
+    vnames=EarthSciData.varnames(fileset)
     @test length(vnames) >= 1
 
-    varname = first(vnames)
-    metadata = EarthSciData.loadmetadata(fileset, varname)
+    varname=first(vnames)
+    metadata=EarthSciData.loadmetadata(fileset, varname)
 
     # Should be a 2D (lon, lat) dataset
     @test length(metadata.varsize) == 2
@@ -44,25 +44,25 @@ end
 end
 
 @testitem "EDGAR Interpolation" setup=[EDGARSetup] tags=[:edgar] begin
-    vnames = EarthSciData.varnames(fileset)
-    varname = first(vnames)
-    sample_time = DateTime(2020, 6, 15)
+    vnames=EarthSciData.varnames(fileset)
+    varname=first(vnames)
+    sample_time=DateTime(2020, 6, 15)
 
-    itp = EarthSciData.DataSetInterpolator{Float32}(fileset, varname, ts, te, domain)
+    itp=EarthSciData.DataSetInterpolator{Float32}(fileset, varname, ts, te, domain)
     # Central Germany (high power plant density)
-    result = EarthSciData.interp(itp, sample_time, deg2rad(10.0f0), deg2rad(51.0f0))
+    result=EarthSciData.interp(itp, sample_time, deg2rad(10.0f0), deg2rad(51.0f0))
     @test result >= 0.0f0
 end
 
 @testitem "EDGAR Monthly Frequency" setup=[EDGARSetup] tags=[:edgar] begin
     using Dates: month
-    vnames = EarthSciData.varnames(fileset)
-    varname = first(vnames)
-    sample_time = DateTime(2020, 6, 15)
+    vnames=EarthSciData.varnames(fileset)
+    varname=first(vnames)
+    sample_time=DateTime(2020, 6, 15)
 
-    itp = EarthSciData.DataSetInterpolator{Float32}(fileset, varname, ts, te, domain)
+    itp=EarthSciData.DataSetInterpolator{Float32}(fileset, varname, ts, te, domain)
     EarthSciData.lazyload!(itp, sample_time)
-    ti = EarthSciData.DataFrequencyInfo(itp.fs.fs)
+    ti=EarthSciData.DataFrequencyInfo(itp.fs.fs)
     @test length(ti.centerpoints) >= 2
     # The cached times should bracket the query month
     @test itp.cache.times[1] <= sample_time
@@ -73,13 +73,13 @@ end
     using ModelingToolkit
     using OrdinaryDiffEqTsit5
 
-    sys = mtkcompile(emis)
-    prob = ODEProblem(
+    sys=mtkcompile(emis)
+    prob=ODEProblem(
         sys,
-        [lat => deg2rad(51.0), lon => deg2rad(10.0), lev => 1.0],
-        (0.0, 60.0),
+        [lat=>deg2rad(51.0), lon=>deg2rad(10.0), lev=>1.0],
+        (0.0, 60.0)
     )
-    sol = solve(prob, Tsit5())
+    sol=solve(prob, Tsit5())
     # Should complete without error
     @test length(sol.t) >= 2
 end
@@ -91,11 +91,11 @@ end
 
 @testitem "EDGAR Coupling with GEOS-FP" setup=[EDGARSetup] tags=[:edgar] begin
     using ModelingToolkit
-    gfp = GEOSFP("4x5", domain)
+    gfp=GEOSFP("4x5", domain)
 
-    csys = couple(emis, gfp)
-    sys = convert(System, csys)
-    eqs = observed(sys)
+    csys=couple(emis, gfp)
+    sys=convert(System, csys)
+    eqs=observed(sys)
 
     @test occursin("EDGARv81MonthlyEmis₊lat(t) ~ GEOSFP₊lat", string(eqs))
 end

--- a/test/edgar_v81_monthly_test.jl
+++ b/test/edgar_v81_monthly_test.jl
@@ -71,12 +71,22 @@ end
 
 @testitem "EDGAR ODE Run" setup=[EDGARSetup] tags=[:edgar] begin
     using ModelingToolkit
+    using ModelingToolkit: t, D
     using OrdinaryDiffEqTsit5
 
-    sys=mtkcompile(emis)
+    # `EDGARv81MonthlyEmis` has no state variables (only parameters and
+    # observed equations), so `ODEProblem` on it directly produces a
+    # DAE with `u0 = Nothing` which errors during solver initialization.
+    # Wrap with a trivial `D(_dummy) ~ 0` state so `solve` has something
+    # to integrate — same pattern used in the GEOSFP/WRF/NCEP tests.
+    @variables _dummy(t)=0.0
+    _sys=compose(System([D(_dummy)~0], t; name = :_w), emis)
+    sys=mtkcompile(_sys)
     prob=ODEProblem(
         sys,
-        [lat=>deg2rad(51.0), lon=>deg2rad(10.0), lev=>1.0],
+        [sys.EDGARv81MonthlyEmis.lat=>deg2rad(51.0),
+            sys.EDGARv81MonthlyEmis.lon=>deg2rad(10.0),
+            sys.EDGARv81MonthlyEmis.lev=>1.0],
         (0.0, 60.0)
     )
     sol=solve(prob, Tsit5())

--- a/test/era5_test.jl
+++ b/test/era5_test.jl
@@ -18,22 +18,22 @@
 
     # ERA5 short variable names with their units and typical value ranges.
     era5_vars = Dict(
-        "t"    => ("K",          "Temperature",                     260.0, 300.0),
-        "u"    => ("m s**-1",    "U component of wind",             -15.0, 15.0),
-        "v"    => ("m s**-1",    "V component of wind",             -15.0, 15.0),
-        "w"    => ("Pa s**-1",   "Vertical velocity",               -1.0,  1.0),
-        "q"    => ("kg kg**-1",  "Specific humidity",                0.0,   0.02),
-        "r"    => ("%",          "Relative humidity",                0.0,   100.0),
-        "z"    => ("m**2 s**-2", "Geopotential",                    0.0,   1e5),
-        "d"    => ("s**-1",      "Divergence",                      -1e-5, 1e-5),
-        "vo"   => ("s**-1",      "Vorticity (relative)",            -1e-5, 1e-5),
-        "o3"   => ("kg kg**-1",  "Ozone mass mixing ratio",         0.0,   1e-5),
-        "cc"   => ("(0 - 1)",    "Fraction of cloud cover",         0.0,   1.0),
-        "ciwc" => ("kg kg**-1",  "Specific cloud ice water content",0.0,   1e-5),
-        "clwc" => ("kg kg**-1",  "Specific cloud liquid water content",0.0,1e-5),
-        "crwc" => ("kg kg**-1",  "Specific rain water content",     0.0,   1e-5),
-        "cswc" => ("kg kg**-1",  "Specific snow water content",     0.0,   1e-5),
-        "pv"   => ("K m**2 kg**-1 s**-1", "Potential vorticity",    -1e-5, 1e-5),
+        "t" => ("K", "Temperature", 260.0, 300.0),
+        "u" => ("m s**-1", "U component of wind", -15.0, 15.0),
+        "v" => ("m s**-1", "V component of wind", -15.0, 15.0),
+        "w" => ("Pa s**-1", "Vertical velocity", -1.0, 1.0),
+        "q" => ("kg kg**-1", "Specific humidity", 0.0, 0.02),
+        "r" => ("%", "Relative humidity", 0.0, 100.0),
+        "z" => ("m**2 s**-2", "Geopotential", 0.0, 1e5),
+        "d" => ("s**-1", "Divergence", -1e-5, 1e-5),
+        "vo" => ("s**-1", "Vorticity (relative)", -1e-5, 1e-5),
+        "o3" => ("kg kg**-1", "Ozone mass mixing ratio", 0.0, 1e-5),
+        "cc" => ("(0 - 1)", "Fraction of cloud cover", 0.0, 1.0),
+        "ciwc" => ("kg kg**-1", "Specific cloud ice water content", 0.0, 1e-5),
+        "clwc" => ("kg kg**-1", "Specific cloud liquid water content", 0.0, 1e-5),
+        "crwc" => ("kg kg**-1", "Specific rain water content", 0.0, 1e-5),
+        "cswc" => ("kg kg**-1", "Specific snow water content", 0.0, 1e-5),
+        "pv" => ("K m**2 kg**-1 s**-1", "Potential vorticity", -1e-5, 1e-5)
     )
 
     for mo in 1:1  # Only January 2022
@@ -46,6 +46,7 @@
         days_in_month = Dates.daysinmonth(2022, mo)
         time_vals = DateTime[]
         for d in 1:days_in_month, h in hours_per_day
+
             push!(time_vals, DateTime(2022, mo, d, h))
         end
         ntime = length(time_vals)
@@ -67,7 +68,7 @@
 
             nctime = defVar(ds, "valid_time", Float64, ("valid_time",),
                 attrib = Dict("units" => "hours since 1900-01-01 00:00:00",
-                              "calendar" => "proleptic_gregorian"))
+                    "calendar" => "proleptic_gregorian"))
             # NCDatasets interprets time automatically if we give DateTimes
             nctime[:] = time_vals
 
@@ -93,7 +94,7 @@
         DateTime(2022, 1, 3);
         latrange = deg2rad(20.0f0):deg2rad(2.0):deg2rad(50.0f0),
         lonrange = deg2rad(-130.0f0):deg2rad(2.0):deg2rad(-60.0f0),
-        levrange = 1:4,  # Corresponding to ERA5 levels: 1000, 975, 950, 925 hPa
+        levrange = 1:4  # Corresponding to ERA5 levels: 1000, 975, 950, 925 hPa
     )
 
     # Lambert Conformal Conic projection centered on the test data domain.
@@ -106,7 +107,7 @@
         xrange = -100_000.0:50_000.0:100_000.0,
         yrange = -100_000.0:50_000.0:100_000.0,
         levrange = 1:4,
-        spatial_ref = lcc_sr,
+        spatial_ref = lcc_sr
     )
 end
 
@@ -114,16 +115,16 @@ end
     using ModelingToolkit: t, D
     using DynamicQuantities
 
-    era5 = ERA5(domain; mirror=era5_mirror)
+    era5=ERA5(domain; mirror = era5_mirror)
 
     # Check that the system has the expected parameters.
-    param_syms = Symbol.(parameters(era5))
+    param_syms=Symbol.(parameters(era5))
     @test :lon in param_syms
     @test :lat in param_syms
     @test :lev in param_syms
 
     # Check that key variables are present (prefixed with pl₊).
-    var_syms = [Symbolics.tosymbol(v, escape=false) for v in unknowns(era5)]
+    var_syms=[Symbolics.tosymbol(v, escape = false) for v in unknowns(era5)]
     @test :pl₊t in var_syms  # Temperature
     @test :pl₊u in var_syms  # U wind
     @test :pl₊v in var_syms  # V wind
@@ -138,14 +139,14 @@ end
 @testitem "ERA5 pressure levels" setup=[ERA5Setup] tags=[:era5] begin
     # Test the pressure-level mapping directly.
     # ERA5_PRESSURE_LEVELS_HPA: [1000, 975, 950, 925, ...]
-    plevs = EarthSciData.ERA5_PRESSURE_LEVELS_HPA
+    plevs=EarthSciData.ERA5_PRESSURE_LEVELS_HPA
     @test plevs[1] == 1000
     @test plevs[2] == 975
     @test plevs[3] == 950
     @test plevs[4] == 925
 
     # Test the interpolator: level index → hPa.
-    itp = EarthSciData.era5_P_itp
+    itp=EarthSciData.era5_P_itp
     @test itp(1.0) ≈ 1000.0
     @test itp(2.0) ≈ 975.0
     @test itp(3.0) ≈ 950.0
@@ -154,9 +155,9 @@ end
     @test itp(1.5) ≈ 987.5
 
     # Verify the pressure equation is present in the system.
-    era5 = ERA5(domain; mirror=era5_mirror)
-    eqs = equations(era5)
-    idx = findfirst(x -> Symbolics.tosymbol(x.lhs, escape=false) == :P, eqs)
+    era5=ERA5(domain; mirror = era5_mirror)
+    eqs=equations(era5)
+    idx=findfirst(x->Symbolics.tosymbol(x.lhs, escape = false)==:P, eqs)
     @test idx !== nothing
 end
 
@@ -164,10 +165,10 @@ end
     using Dates
     using DynamicQuantities
 
-    era5_fs = EarthSciData.ERA5PressureLevelFileSet(domain; mirror=era5_mirror)
+    era5_fs=EarthSciData.ERA5PressureLevelFileSet(domain; mirror = era5_mirror)
 
     # Test metadata loading.
-    md = EarthSciData.loadmetadata(era5_fs, "t")
+    md=EarthSciData.loadmetadata(era5_fs, "t")
     @test md.xdim > 0
     @test md.ydim > 0
     @test md.zdim > 0
@@ -179,30 +180,31 @@ end
     @test issorted(md.coords[md.ydim])  # Latitude should be ascending.
 
     # Test that we can create a DataSetInterpolator and load data.
-    dt = EarthSciMLBase.dtype(domain)
-    starttime, endtime = EarthSciMLBase.get_tspan_datetime(domain)
-    itp = EarthSciData.DataSetInterpolator{dt}(
-        era5_fs, "t", starttime, endtime, domain; stream=true
+    dt=EarthSciMLBase.dtype(domain)
+    starttime, endtime=EarthSciMLBase.get_tspan_datetime(domain)
+    itp=EarthSciData.DataSetInterpolator{dt}(
+        era5_fs, "t", starttime, endtime, domain; stream = true
     )
     @test EarthSciData.units(itp) == u"K"
 
     # Test interpolation at a specific point.
-    tt = DateTime(2022, 1, 1, 12, 0, 0)
-    lonv = deg2rad(-90.0)
-    latv = deg2rad(35.0)
-    levv = 1.0
-    val = EarthSciData.interp(itp, tt, lonv, latv, levv)
+    tt=DateTime(2022, 1, 1, 12, 0, 0)
+    lonv=deg2rad(-90.0)
+    latv=deg2rad(35.0)
+    levv=1.0
+    EarthSciData.lazyload!(itp, tt)
+    val=EarthSciData.interp_unsafe(itp, tt, lonv, latv, levv)
     # Temperature should be reasonable (200-320 K at 1000 hPa).
     @test 200.0 < val < 320.0
 end
 
 @testitem "ERA5 varnames" setup=[ERA5Setup] tags=[:era5] begin
-    era5_fs = EarthSciData.ERA5PressureLevelFileSet(domain; mirror=era5_mirror)
-    vnames = EarthSciData.varnames(era5_fs)
+    era5_fs=EarthSciData.ERA5PressureLevelFileSet(domain; mirror = era5_mirror)
+    vnames=EarthSciData.varnames(era5_fs)
 
     # All 16 variables should be present.
-    expected = ["t", "u", "v", "w", "q", "r", "z", "d", "vo", "o3",
-                "cc", "ciwc", "clwc", "crwc", "cswc", "pv"]
+    expected=["t", "u", "v", "w", "q", "r", "z", "d", "vo", "o3",
+        "cc", "ciwc", "clwc", "crwc", "cswc", "pv"]
     for v in expected
         @test v in vnames
     end
@@ -210,18 +212,19 @@ end
 
 @testitem "ERA5 ODE integration" setup=[ERA5Setup] tags=[:era5] begin
     using ModelingToolkit
+    using ModelingToolkit: t, D
     using OrdinaryDiffEqTsit5
 
-    era5 = ERA5(domain; mirror=era5_mirror)
-    lon, lat, lev = EarthSciMLBase.pvars(domain)
+    era5=ERA5(domain; mirror = era5_mirror)
 
-    sys = mtkcompile(era5)
-    prob = ODEProblem(
-        sys,
-        [lon => deg2rad(-90.0), lat => deg2rad(35.0), lev => 1.0],
-        (0.0, 60.0),
-    )
-    sol = solve(prob, Tsit5())
+    # ERA5 has no state variables (only observed/parameter equations), so wrap
+    # with a trivial dummy state so that ODEProblem + solve work.
+    @variables _dummy(t) = 0.0
+    _sys=compose(System([D(_dummy)~0], t; name = :_w), era5)
+    compiled=mtkcompile(_sys)
+
+    prob=ODEProblem(compiled, [], (0.0, 60.0))
+    sol=solve(prob, Tsit5())
     # Should complete without error and produce multiple time steps.
     @test length(sol.t) >= 2
 end
@@ -231,41 +234,42 @@ end
     using DynamicQuantities
     using EarthSciMLBase: Advection
 
-    era5 = ERA5(domain; mirror=era5_mirror)
+    era5=ERA5(domain; mirror = era5_mirror)
 
     # Add ERA5 partial derivative transform for vertical coordinate (like GEOSFP pattern).
-    domain2 = EarthSciMLBase.add_partial_derivative_func(
+    domain2=EarthSciMLBase.add_partial_derivative_func(
         domain,
-        partialderivatives_δPδlev_era5(),
+        partialderivatives_δPδlev_era5()
     )
 
     # Create a simple system with lon/lat as parameters (matching the GEOSFP test pattern).
-    lon, lat, _ = EarthSciMLBase.pvars(domain2)
+    lon, lat, _=EarthSciMLBase.pvars(domain2)
     @variables c(ModelingToolkit.t) = 5.0 [unit = u"mol/m^3"]
-    @constants c_unit = 6.0 [unit = u"rad", description = "constant to make units cancel out"]
+    @constants c_unit = 6.0 [
+        unit = u"rad", description = "constant to make units cancel out"]
 
     struct ERA5TestCoupler
         sys::Any
     end
 
-    exsys = System(
-        [ModelingToolkit.D(c) ~ (sin(lat * c_unit) + sin(lon * c_unit)) * c / ModelingToolkit.t],
+    exsys=System(
+        [ModelingToolkit.D(c)~(sin(lat*c_unit)+sin(lon*c_unit))*c/ModelingToolkit.t],
         ModelingToolkit.t;
         name = :TestSys,
-        metadata = Dict(EarthSciMLBase.CoupleType => ERA5TestCoupler),
+        metadata = Dict(EarthSciMLBase.CoupleType=>ERA5TestCoupler)
     )
 
     function EarthSciMLBase.couple2(e::ERA5TestCoupler, g::EarthSciData.ERA5Coupler)
-        e, g = e.sys, g.sys
-        e = EarthSciMLBase.param_to_var(e, :lat, :lon)
-        ConnectorSystem([e.lat ~ g.lat, e.lon ~ g.lon], e, g)
+        e, g=e.sys, g.sys
+        e=EarthSciMLBase.param_to_var(e, :lat, :lon)
+        ConnectorSystem([e.lat~g.lat, e.lon~g.lon], e, g)
     end
 
-    composed = couple(exsys, domain2, Advection(), era5)
-    pde_sys = convert(PDESystem, composed)
-    eqs = equations(pde_sys)
-    eqs_str = string.(eqs)
-    eqs_joined = join(eqs_str, " ")
+    composed=couple(exsys, domain2, Advection(), era5)
+    pde_sys=convert(PDESystem, composed)
+    eqs=equations(pde_sys)
+    eqs_str=string.(eqs)
+    eqs_joined=join(eqs_str, " ")
 
     # MeanWind should couple to ERA5's u, v, w wind components.
     @test any(occursin("MeanWind", s) for s in eqs_str)
@@ -280,10 +284,10 @@ end
     using ModelingToolkit: t, D
     using DynamicQuantities
 
-    era5 = ERA5(xy_domain; mirror=era5_mirror)
+    era5=ERA5(xy_domain; mirror = era5_mirror)
 
     # Check that the system has x/y parameters (not lon/lat).
-    param_syms = Symbol.(parameters(era5))
+    param_syms=Symbol.(parameters(era5))
     @test :x in param_syms
     @test :y in param_syms
     @test :lev in param_syms
@@ -291,7 +295,7 @@ end
     @test !(:lat in param_syms)
 
     # Key variables should still be present.
-    var_syms = [Symbolics.tosymbol(v, escape=false) for v in unknowns(era5)]
+    var_syms=[Symbolics.tosymbol(v, escape = false) for v in unknowns(era5)]
     @test :pl₊t in var_syms
     @test :pl₊u in var_syms
     @test :pl₊v in var_syms
@@ -304,18 +308,18 @@ end
 
 @testitem "ERA5 xy-domain ODE integration" setup=[ERA5Setup] tags=[:era5] begin
     using ModelingToolkit
+    using ModelingToolkit: t, D
     using OrdinaryDiffEqTsit5
 
-    era5 = ERA5(xy_domain; mirror=era5_mirror)
-    x, y, lev = EarthSciMLBase.pvars(xy_domain)
+    era5=ERA5(xy_domain; mirror = era5_mirror)
 
-    sys = mtkcompile(era5)
-    prob = ODEProblem(
-        sys,
-        [x => 0.0, y => 0.0, lev => 1.0],
-        (0.0, 60.0),
-    )
-    sol = solve(prob, Tsit5())
+    # ERA5 has no state variables — wrap with a dummy DV.
+    @variables _dummy(t) = 0.0
+    _sys=compose(System([D(_dummy)~0], t; name = :_w), era5)
+    compiled=mtkcompile(_sys)
+
+    prob=ODEProblem(compiled, [], (0.0, 60.0))
+    sol=solve(prob, Tsit5())
     @test length(sol.t) >= 2
 end
 
@@ -324,14 +328,14 @@ end
     using DynamicQuantities
     using EarthSciMLBase: Advection
 
-    era5 = ERA5(xy_domain; mirror=era5_mirror)
+    era5=ERA5(xy_domain; mirror = era5_mirror)
 
-    xy_domain2 = EarthSciMLBase.add_partial_derivative_func(
+    xy_domain2=EarthSciMLBase.add_partial_derivative_func(
         xy_domain,
-        partialderivatives_δPδlev_era5(),
+        partialderivatives_δPδlev_era5()
     )
 
-    x, y, _ = EarthSciMLBase.pvars(xy_domain2)
+    x, y, _=EarthSciMLBase.pvars(xy_domain2)
     @variables c(ModelingToolkit.t) = 5.0 [unit = u"mol/m^3"]
     @constants c_unit = 6.0 [unit = u"m", description = "constant to make units cancel out"]
 
@@ -339,24 +343,24 @@ end
         sys::Any
     end
 
-    exsys = System(
-        [ModelingToolkit.D(c) ~ (sin(x / c_unit) + sin(y / c_unit)) * c / ModelingToolkit.t],
+    exsys=System(
+        [ModelingToolkit.D(c)~(sin(x/c_unit)+sin(y/c_unit))*c/ModelingToolkit.t],
         ModelingToolkit.t;
         name = :TestSys,
-        metadata = Dict(EarthSciMLBase.CoupleType => ERA5XYTestCoupler),
+        metadata = Dict(EarthSciMLBase.CoupleType=>ERA5XYTestCoupler)
     )
 
     function EarthSciMLBase.couple2(e::ERA5XYTestCoupler, g::EarthSciData.ERA5Coupler)
-        e, g = e.sys, g.sys
-        e = EarthSciMLBase.param_to_var(e, :x, :y)
-        ConnectorSystem([e.x ~ g.x, e.y ~ g.y], e, g)
+        e, g=e.sys, g.sys
+        e=EarthSciMLBase.param_to_var(e, :x, :y)
+        ConnectorSystem([e.x~g.x, e.y~g.y], e, g)
     end
 
-    composed = couple(exsys, xy_domain2, Advection(), era5)
-    pde_sys = convert(PDESystem, composed)
-    eqs = equations(pde_sys)
-    eqs_str = string.(eqs)
-    eqs_joined = join(eqs_str, " ")
+    composed=couple(exsys, xy_domain2, Advection(), era5)
+    pde_sys=convert(PDESystem, composed)
+    eqs=equations(pde_sys)
+    eqs_str=string.(eqs)
+    eqs_joined=join(eqs_str, " ")
 
     # MeanWind should couple to ERA5's u, v, w wind components.
     @test any(occursin("MeanWind", s) for s in eqs_str)

--- a/test/geosfp_test.jl
+++ b/test/geosfp_test.jl
@@ -115,7 +115,8 @@ end
           [102340.37924047427, 101572.77264006894, 100805.16603966363, 2.0, 1.5, 1.0]
 end
 
-@testitem "GEOS-FP ground-level vertical velocity" setup=[GEOSFPDomainSetup, GEOSFPSolvedSetup] begin
+@testitem "GEOS-FP ground-level vertical velocity" setup=[
+    GEOSFPDomainSetup, GEOSFPSolvedSetup] begin
     prob = ODEProblem(compiled, [], (24.0 * 3600, 48.0 * 3600))
     integ = init(prob, Tsit5())
     f = getsym(integ, compiled.GEOSFP.A3dyn₊OMEGA)

--- a/test/geosfp_test.jl
+++ b/test/geosfp_test.jl
@@ -61,11 +61,11 @@ end
         "MeanWind₊v_lev(t, lon, lat, lev)",
         "GEOSFP₊A3dyn₊OMEGA(t, lon, lat, lev)",
         "GEOSFP₊A3dyn₊U(t, lon, lat, lev)",
-        "GEOSFP₊A3dyn₊U_itp(GEOSFP₊t_ref + t, lon, lat, lev)",
+        "interp_unsafe(GEOSFP₊A3dyn₊U_data",
         "GEOSFP₊A3dyn₊OMEGA(t, lon, lat, lev)",
-        "GEOSFP₊A3dyn₊OMEGA_itp(GEOSFP₊t_ref + t, lon, lat, lev)",
+        "interp_unsafe(GEOSFP₊A3dyn₊OMEGA_data",
         "GEOSFP₊A3dyn₊V(t, lon, lat, lev)",
-        "GEOSFP₊A3dyn₊V_itp(GEOSFP₊t_ref + t, lon, lat, lev)",
+        "interp_unsafe(GEOSFP₊A3dyn₊V_data",
         "Differential(t, 1)(ExampleSys₊c(t, lon, lat, lev))",
         "Differential(lon, 1)(ExampleSys₊c(t, lon, lat, lev)",
         "MeanWind₊v_lon(t, lon, lat, lev)",
@@ -88,71 +88,74 @@ end
     end
 end
 
-@testitem "GEOS-FP pressure levels" setup=[GEOSFPDomainSetup] begin
+# Helper: wrap a parameter-only data system with a trivial state variable
+# so that ODEProblem + init/solve work (DiffEq requires at least one DV).
+@testsnippet GEOSFPSolvedSetup begin
+    using ModelingToolkit: t, D
+    using OrdinaryDiffEqTsit5
     using SymbolicIndexingInterface: setp, getsym, parameter_values
 
-    geosfp = mtkcompile(GEOSFP("4x5", domain))
-    prob = ODEProblem(geosfp, [], (24.0 * 3600, 48.0 * 3600))
-    f = getsym(prob, geosfp.P)
-    setter = setp(geosfp, [geosfp.lon, geosfp.lat, geosfp.lev])
-    ps = parameter_values(prob)
+    geosfp_raw = GEOSFP("4x5", domain)
+    @variables _dummy(t) = 0.0
+    _sys = compose(System([D(_dummy) ~ 0], t; name = :_w), geosfp_raw)
+    compiled = mtkcompile(_sys)
+end
+
+@testitem "GEOS-FP pressure levels" setup=[GEOSFPDomainSetup, GEOSFPSolvedSetup] begin
+    prob = ODEProblem(compiled, [], (24.0 * 3600, 48.0 * 3600))
+    integ = init(prob, Tsit5())
+    f = getsym(integ, compiled.GEOSFP.P)
+    setter = setp(integ, [compiled.GEOSFP.lon, compiled.GEOSFP.lat, compiled.GEOSFP.lev])
 
     p_levels = map([1, 1.5, 2, 72, 72.5, 73]) do lev
-        setter(prob, [deg2rad(-155.7), deg2rad(39.1), lev])
-        f(prob)
+        setter(integ, [deg2rad(-155.7), deg2rad(39.1), lev])
+        f(integ)
     end
     @test p_levels ≈
           [102340.37924047427, 101572.77264006894, 100805.16603966363, 2.0, 1.5, 1.0]
 end
 
-@testitem "GEOS-FP ground-level vertical velocity" setup=[GEOSFPDomainSetup] begin
-    using SymbolicIndexingInterface: setp, getsym, parameter_values
-
-    geosfp = mtkcompile(GEOSFP("4x5", domain))
-    prob = ODEProblem(geosfp, [], (24.0 * 3600, 48.0 * 3600))
-    f = getsym(prob, geosfp.A3dyn₊OMEGA)
-    setter = setp(geosfp, [geosfp.lon, geosfp.lat, geosfp.lev])
-    ps = parameter_values(prob)
+@testitem "GEOS-FP ground-level vertical velocity" setup=[GEOSFPDomainSetup, GEOSFPSolvedSetup] begin
+    prob = ODEProblem(compiled, [], (24.0 * 3600, 48.0 * 3600))
+    integ = init(prob, Tsit5())
+    f = getsym(integ, compiled.GEOSFP.A3dyn₊OMEGA)
+    setter = setp(integ, [compiled.GEOSFP.lon, compiled.GEOSFP.lat, compiled.GEOSFP.lev])
 
     omega_levels = map([0.5, 1, 1.5, 2, 72, 72.5, 73]) do lev
-        setter(prob, [deg2rad(-155.7), deg2rad(39.1), lev])
-        f(prob)
+        setter(integ, [deg2rad(-155.7), deg2rad(39.1), lev])
+        f(integ)
     end
     @test omega_levels ≈ [0.0, -0.0038511699971381114, -0.007702339994276223,
         -0.006515003709544222, 1.1196587112172361e-5, 0.0, 0.0]
 end
 
-@testitem "GEOS-FP new day" setup=[GEOSFPDomainSetup] begin
-    using SymbolicIndexingInterface: getsym
-    geosfp = mtkcompile(GEOSFP("4x5", domain))
+@testitem "GEOS-FP new day" setup=[GEOSFPDomainSetup, GEOSFPSolvedSetup] begin
     tspan = datetime2unix.((DateTime(2022, 1, 1, 23, 58), DateTime(2022, 1, 2, 0, 3))) .-
             get_tref(domain)
-    prob = ODEProblem(geosfp, [], tspan)
-    f = getsym(prob, geosfp.I3₊PS)
-    @test f(prob) ≈ 101193.67232405252
+    prob = ODEProblem(compiled, [], tspan)
+    integ = init(prob, Tsit5())
+    f = getsym(integ, compiled.GEOSFP.I3₊PS)
+    @test f(integ) ≈ 101193.67232405252
 end
-@testitem "GEOS-FP wrong month" setup=[GEOSFPDomainSetup] begin
-    using SymbolicIndexingInterface: getsym
-    geosfp = mtkcompile(GEOSFP("4x5", domain))
+
+@testitem "GEOS-FP wrong month" setup=[GEOSFPDomainSetup, GEOSFPSolvedSetup] begin
     tspan = datetime2unix.((DateTime(2022, 5, 1), DateTime(2022, 5, 2))) .-
             get_tref(domain)
-    prob = ODEProblem(geosfp, [], tspan)
-    f = getsym(prob, geosfp.I3₊PS)
-    @test_throws Base.Exception f(prob)
+    prob = ODEProblem(compiled, [], tspan)
+    # The initialize callback fires at tspan[1] which is outside the dataset
+    # range — expect an error during init.
+    @test_throws Base.Exception init(prob, Tsit5())
 end
 
-@testitem "GEOS-FP height above ground" setup=[GEOSFPDomainSetup] begin
-    using SymbolicIndexingInterface: setp, getsym, parameter_values
-
-    geosfp = mtkcompile(GEOSFP("4x5", domain))
-    prob = ODEProblem(geosfp, [], (24.0 * 3600, 48.0 * 3600))
-    f = getsym(prob, geosfp.Z_agl)
-    setter = setp(geosfp, [geosfp.lon, geosfp.lat, geosfp.lev])
-    ps = parameter_values(prob)
+@testitem "GEOS-FP height above ground" setup=[GEOSFPDomainSetup, GEOSFPSolvedSetup] begin
+    prob = ODEProblem(compiled, [], (24.0 * 3600, 48.0 * 3600))
+    integ = init(prob, Tsit5())
+    f = getsym(integ, compiled.GEOSFP.Z_agl)
+    setter = setp(integ, [compiled.GEOSFP.lon, compiled.GEOSFP.lat, compiled.GEOSFP.lev])
 
     z_levels = map([1, 1.5, 2, 72, 72.5]) do lev
-        setter(prob, [deg2rad(-155.7), deg2rad(39.1), lev])
-        f(prob)
+        setter(integ, [deg2rad(-155.7), deg2rad(39.1), lev])
+        f(integ)
     end
     @test z_levels ≈ [63.38451747881698, 127.11513708190306, 191.83774317607677,
         77316.16731665366, 80132.63935650676]

--- a/test/landfire_test.jl
+++ b/test/landfire_test.jl
@@ -88,7 +88,7 @@ end
         fswr, "fuel_model", ts, te, domain; stream = true)
     lon_c=deg2rad(-121.60)
     lat_c=deg2rad(39.78)
-    val=EarthSciData.interp(itp, ts, Float32(lon_c), Float32(lat_c))
+    val=EarthSciData.interp!(itp, ts, Float32(lon_c), Float32(lat_c))
     # Nearest-neighbour should produce integer-valued results
     @test val ≈ round(val)
     @test val >= 0

--- a/test/landfire_test.jl
+++ b/test/landfire_test.jl
@@ -129,7 +129,7 @@ end
 end
 
 @testitem "LANDFIRE LCC bbox helper" setup=[LANDFIRELCCSetup] tags=[:landfire] begin
-    lon_min, lat_min, lon_max, lat_max = EarthSciData._domain_bbox_wgs84(domain_lcc)
+    lon_min, lat_min, lon_max, lat_max=EarthSciData._domain_bbox_wgs84(domain_lcc)
     @test lon_min < -121.6 < lon_max
     @test lat_min < 39.78 < lat_max
     # Bbox should be reasonable (not huge)
@@ -138,7 +138,7 @@ end
 end
 
 @testitem "LANDFIRE LCC FileSet construction" setup=[LANDFIRELCCSetup] tags=[:landfire] begin
-    fs = EarthSciData.LANDFIREFileSet(domain_lcc)
+    fs=EarthSciData.LANDFIREFileSet(domain_lcc)
     @test fs.product == "FBFM13"
     @test fs.bbox[1] < -121.6 < fs.bbox[3]
     @test fs.bbox[2] < 39.78 < fs.bbox[4]
@@ -147,22 +147,22 @@ end
 end
 
 @testitem "LANDFIRE LCC data loading" setup=[LANDFIRELCCSetup] tags=[:landfire] begin
-    fs = EarthSciData.LANDFIREFileSet(domain_lcc; resolution = 10.0)
-    md = EarthSciData.loadmetadata(fs, "fuel_model")
-    data = zeros(Float32, md.varsize...)
-    ts, _ = EarthSciMLBase.get_tspan_datetime(domain_lcc)
+    fs=EarthSciData.LANDFIREFileSet(domain_lcc; resolution = 10.0)
+    md=EarthSciData.loadmetadata(fs, "fuel_model")
+    data=zeros(Float32, md.varsize...)
+    ts, _=EarthSciMLBase.get_tspan_datetime(domain_lcc)
     EarthSciData.loadslice!(data, fs, ts, "fuel_model")
-    valid_codes = Set([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13,
+    valid_codes=Set([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13,
         91, 92, 93, 98, 99])
-    unique_vals = Set(round.(Int, unique(data)))
+    unique_vals=Set(round.(Int, unique(data)))
     @test length(unique_vals) > 1
     @test all(v -> v in valid_codes, unique_vals)
 end
 
 @testitem "LANDFIRE LCC System" setup=[LANDFIRELCCSetup] tags=[:landfire] begin
-    sys = LANDFIRE(domain_lcc; resolution = 10.0)
+    sys=LANDFIRE(domain_lcc; resolution = 10.0)
     @test sys isa ModelingToolkit.AbstractSystem
     @test length(equations(sys)) >= 1
-    eq_names = [Symbolics.tosymbol(eq.lhs, escape = false) for eq in equations(sys)]
+    eq_names=[Symbolics.tosymbol(eq.lhs, escape = false) for eq in equations(sys)]
     @test :fuel_model ∈ eq_names
 end

--- a/test/load_test.jl
+++ b/test/load_test.jl
@@ -358,19 +358,30 @@ end
     # `DataBufferType{Array{Float32, N}}` — separate buckets for 2D+t and
     # 3D+t data arrays). After the initialize callback fires, the buffers
     # should be populated with real data, still Float32, no promotion.
-    pbuf = integ.p
-    found_nonzero_f32 = false
-    for buf in pbuf.discrete
-        T = eltype(buf)
-        T <: EarthSciData.DataBufferType || continue
-        for entry in buf
-            @test entry.data isa Array{Float32}
-            @test eltype(entry.data) === Float32
-            if any(!iszero, entry.data)
-                found_nonzero_f32 = true
+    # Wrap the scan in a function to avoid the `@testitem`-soft-scope
+    # ambiguity with the `found_nonzero_f32` assignment inside the loop.
+    function scan_buffers(pbuf)
+        all_f32 = true
+        found_nonzero_f32 = false
+        for buf in pbuf.discrete
+            T = eltype(buf)
+            T <: EarthSciData.DataBufferType || continue
+            for entry in buf
+                if !(entry.data isa Array{Float32})
+                    all_f32 = false
+                end
+                if eltype(entry.data) !== Float32
+                    all_f32 = false
+                end
+                if any(!iszero, entry.data)
+                    found_nonzero_f32 = true
+                end
             end
         end
+        return all_f32, found_nonzero_f32
     end
+    all_f32, found_nonzero_f32 = scan_buffers(integ.p)
+    @test all_f32
     @test found_nonzero_f32
 end
 
@@ -431,25 +442,6 @@ end
     r = EarthSciData.knots2range([5.0])
     @test length(r) == 1
     @test first(r) == 5.0
-end
-
-@testitem "create_interpolator! with singleton dims" begin
-    using EarthSciData
-    using Interpolations: BSpline, Linear, interpolate!, scale
-    using Dates: DateTime, Hour, datetime2unix
-
-    # 2D spatial with one singleton dim + time
-    coords = (0.0:0.1:0.3, 0.0:1.0:0.0)  # dim 2 is singleton (length 1)
-    times = [DateTime(2024, 1, 1) + Hour(i) for i in 0:1]
-    data = ones(Float32, 4, 1, 2)
-    interp_cache = similar(data)
-
-    grid, itp = EarthSciData.create_interpolator!(interp_cache, data, coords, times)
-    @test length(grid) == 3
-    @test length(grid[2]) == 2  # singleton padded to 2
-
-    # Query should work — value should be 1.0 everywhere
-    @test itp(0.1, 0.5, datetime2unix(times[1])) ≈ 1.0f0
 end
 
 @testitem "DummyFileSet singleton dim" begin

--- a/test/load_test.jl
+++ b/test/load_test.jl
@@ -186,7 +186,8 @@ end
 
     interp!(itp, times[end], xs[end], xs[end])
     @test length(itp.cache.times) == 2
-    @test itp.cache.times == [DateTime("2022-05-02T22:30:00"), DateTime("2022-05-03T01:30:00")]
+    @test itp.cache.times ==
+          [DateTime("2022-05-02T22:30:00"), DateTime("2022-05-03T01:30:00")]
 
     uvals = zeros(Float32, length(times), length(xs))
     answers = zeros(Float32, length(times), length(xs))
@@ -254,7 +255,8 @@ end
     using Dates: DateTime, Hour, datetime2unix
 
     # Float32 coords (as when DomainInfo uses Float32 u_proto)
-    coords_f32 = (Float32(0.0):Float32(0.1):Float32(0.3), Float32(0.0):Float32(0.1):Float32(0.3))
+    coords_f32 = (
+        Float32(0.0):Float32(0.1):Float32(0.3), Float32(0.0):Float32(0.1):Float32(0.3))
     times = [DateTime(2024, 1, 1) + Hour(i) for i in 0:1]
     data = zeros(Float32, 4, 4, 2)
     interp_cache = similar(data)
@@ -294,7 +296,7 @@ end
         EarthSciData.MetaData(
             [[0.0, 1.0], [0.0, 1.0]],
             "m", "test", ["x", "y"], [2, 2],
-            "+proj=longlat +datum=WGS84 +no_defs", 1, 2, -1, (false, false, false),
+            "+proj=longlat +datum=WGS84 +no_defs", 1, 2, -1, (false, false, false)
         )
     end
 
@@ -302,10 +304,11 @@ end
         DateTime(2024, 1, 1), DateTime(2024, 1, 2);
         lonrange = deg2rad(0.0):deg2rad(1.0):deg2rad(1.0),
         latrange = deg2rad(0.0):deg2rad(1.0):deg2rad(1.0),
-        levrange = 1:1,
+        levrange = 1:1
     )
     fs = BoundaryCacheTestFS(DateTime(2024, 1, 1), DateTime(2024, 1, 2))
-    itp = EarthSciData.DataSetInterpolator{Float64}(fs, "X", DateTime(2024, 1, 1), DateTime(2024, 1, 2), domain)
+    itp = EarthSciData.DataSetInterpolator{Float64}(
+        fs, "X", DateTime(2024, 1, 1), DateTime(2024, 1, 2), domain)
 
     # At the last centerpoint, should not throw BoundsError
     times = EarthSciData.interp_cache_times!(itp, DateTime(2024, 1, 2))
@@ -417,7 +420,8 @@ end
     )
 
     # Should be able to interpolate without error
-    val = EarthSciData.interp(itp, DateTime(2022, 5, 1, 1), deg2rad(0.25f0), deg2rad(0.5f0), 1.0f0)
+    val = EarthSciData.interp(
+        itp, DateTime(2022, 5, 1, 1), deg2rad(0.25f0), deg2rad(0.5f0), 1.0f0)
     @test !isnan(val)
     @test isfinite(val)
 end

--- a/test/load_test.jl
+++ b/test/load_test.jl
@@ -1,4 +1,5 @@
 @testsnippet LoadSetup begin
+    using EarthSciData
     using EarthSciMLBase
     using Dates
 
@@ -84,6 +85,7 @@ end
 end
 
 @testitem "DummyFileSet" begin
+    using EarthSciData
     using EarthSciMLBase: DomainInfo
     using Dates: datetime2unix, DateTime, Second, Hour
     using Interpolations: scale, interpolate, BSpline, Linear
@@ -433,18 +435,21 @@ end
 end
 
 @testitem "tuple_from_vals" begin
+    using EarthSciData
     @test EarthSciData.tuple_from_vals(1, 1, 2, 2, 3, 3) == (1, 2, 3)
     @test EarthSciData.tuple_from_vals(2, 2, 1, 1, 3, 3) == (1, 2, 3)
     @test EarthSciData.tuple_from_vals(3, 3, 2, 2, 1, 1) == (1, 2, 3)
 end
 
 @testitem "knots2range singleton" begin
+    using EarthSciData
     r = EarthSciData.knots2range([5.0])
     @test length(r) == 1
     @test first(r) == 5.0
 end
 
 @testitem "DummyFileSet singleton dim" begin
+    using EarthSciData
     using EarthSciMLBase: DomainInfo
     using Dates: datetime2unix, DateTime, Second, Hour
     using Interpolations: scale, interpolate, BSpline, Linear

--- a/test/load_test.jl
+++ b/test/load_test.jl
@@ -420,7 +420,7 @@ end
     )
 
     # Should be able to interpolate without error
-    val = EarthSciData.interp(
+    val = EarthSciData.interp!(
         itp, DateTime(2022, 5, 1, 1), deg2rad(0.25f0), deg2rad(0.5f0), 1.0f0)
     @test !isnan(val)
     @test isfinite(val)

--- a/test/load_test.jl
+++ b/test/load_test.jl
@@ -249,29 +249,74 @@ if !Sys.iswindows() # Allocation tests don't seem to work on windows.
     end
 end
 
-@testitem "create_interpolator! with Float32 coords" begin
+@testitem "Float32 DomainInfo → Float32 data buffer (no Float64 promotion)" begin
     using EarthSciData
-    using Interpolations: BSpline, Linear, interpolate!, scale
-    using Dates: DateTime, Hour, datetime2unix
+    using EarthSciMLBase
+    using ModelingToolkit
+    using ModelingToolkit: t, D
+    using Dates
+    using DynamicQuantities
+    using OrdinaryDiffEqTsit5
+    using SymbolicIndexingInterface: setp, getsym
 
-    # Float32 coords (as when DomainInfo uses Float32 u_proto)
-    coords_f32 = (
-        Float32(0.0):Float32(0.1):Float32(0.3), Float32(0.0):Float32(0.1):Float32(0.3))
-    times = [DateTime(2024, 1, 1) + Hour(i) for i in 0:1]
-    data = zeros(Float32, 4, 4, 2)
-    interp_cache = similar(data)
-    grid, itp = EarthSciData.create_interpolator!(interp_cache, data, coords_f32, times)
+    # DomainInfo with Float32 u_proto — forces the element type through every
+    # downstream allocation. This is the CPU-side dress rehearsal for GPU
+    # execution: `similar(domain.u_proto, ...)` should preserve element type
+    # without promoting to Float64, and the interpolation path should not
+    # allocate Float64 intermediates.
+    domain = DomainInfo(
+        DateTime(2022, 1, 1),
+        DateTime(2022, 1, 3);
+        latrange = deg2rad(-85.0f0):deg2rad(2):deg2rad(85.0f0),
+        lonrange = deg2rad(-180.0f0):deg2rad(2.5):deg2rad(175.0f0),
+        levrange = 1:73,
+        u_proto = zeros(Float32, 0)
+    )
+    @test eltype(domain.u_proto) === Float32
 
-    # All ranges in the grid should be Float64
-    for r in grid
-        @test eltype(r) == Float64
+    geosfp = GEOSFP("4x5", domain)
+
+    # The `getdefault` of every _data parameter should be a Float32 Array
+    # (MTK stores the raw default pre-conversion; the conversion to
+    # `DataBufferType{Array{Float32,N}}` happens when `MTKParameters` is
+    # built — verified below).
+    ps = parameters(geosfp)
+    data_ps = [p for p in ps if endswith(string(ModelingToolkit.getname(p)), "_data")]
+    @test !isempty(data_ps)
+    for p in data_ps
+        default = ModelingToolkit.getdefault(p)
+        @test default isa Array{Float32}
+        @test eltype(default) === Float32
     end
 
-    # A second call (simulating update_interpolator!) should produce the same type
-    data2 = ones(Float32, 4, 4, 2)
-    interp_cache2 = similar(data2)
-    grid2, itp2 = EarthSciData.create_interpolator!(interp_cache2, data2, coords_f32, times)
-    @test typeof(itp) == typeof(itp2)
+    # Build a trivial wrapper system so ODEProblem/init work (GEOSFP alone has
+    # no state variables) and verify the initialize callback loads data
+    # without promoting the buffer.
+    @variables _dummy(t) = 0.0f0
+    _sys = compose(System([D(_dummy) ~ 0], t; name = :_w), geosfp)
+    compiled = mtkcompile(_sys)
+    prob = ODEProblem(compiled, [], (24.0 * 3600, 48.0 * 3600))
+    integ = init(prob, Tsit5())
+
+    # The `@discretes`-declared data buffers live in `p.discrete`, split into
+    # sub-buffers by symtype (one bucket per distinct concrete
+    # `DataBufferType{Array{Float32, N}}` — separate buckets for 2D+t and
+    # 3D+t data arrays). After the initialize callback fires, the buffers
+    # should be populated with real data, still Float32, no promotion.
+    pbuf = integ.p
+    found_nonzero_f32 = false
+    for buf in pbuf.discrete
+        T = eltype(buf)
+        T <: EarthSciData.DataBufferType || continue
+        for entry in buf
+            @test entry.data isa Array{Float32}
+            @test eltype(entry.data) === Float32
+            if any(!iszero, entry.data)
+                found_nonzero_f32 = true
+            end
+        end
+    end
+    @test found_nonzero_f32
 end
 
 @testitem "interp_cache_times! boundary" begin

--- a/test/load_test.jl
+++ b/test/load_test.jl
@@ -249,6 +249,61 @@ if !Sys.iswindows() # Allocation tests don't seem to work on windows.
     end
 end
 
+@testitem "interp_unsafe / interp_time_only are type-stable and non-allocating" begin
+    using EarthSciData
+    using Test: @inferred
+
+    # The RHS of every MTK-generated simulation calls these functions millions
+    # of times per solve.  They must be both type-stable (so the compiler can
+    # emit efficient code) and allocation-free (so the GC doesn't thrash).
+    #
+    # The `DataBufferType` wrapper is the load-bearing part: `interp_unsafe`
+    # runs a forward through `data.data`, and if that access ever boxes
+    # (because `data::Any` or `data::AbstractArray`) the whole thing becomes
+    # dynamic and allocations go up.
+    for T in (Float64, Float32)
+        # ----- 4D (3 spatial + time) — atmospheric data -----
+        data4 = rand(T, 10, 10, 10, 2)
+        db4 = EarthSciData.DataBufferType(data4)
+        fit = T(1.5)
+        fi1, fi2, fi3 = T(5.3), T(5.7), T(5.2)
+        extrap = T(1.0)
+
+        # Type stability: @inferred throws if the return type is not concrete.
+        @test @inferred(EarthSciData.interp_unsafe(db4, fit, fi1, fi2, fi3, extrap)) isa T
+        @test @inferred(EarthSciData.interp_time_only(db4, fit, fi1, fi2, fi3, extrap)) isa
+              T
+
+        # Allocation: zero heap allocations after warmup.
+        EarthSciData.interp_unsafe(db4, fit, fi1, fi2, fi3, extrap)  # warmup
+        EarthSciData.interp_time_only(db4, fit, fi1, fi2, fi3, extrap)
+        @test (@allocated EarthSciData.interp_unsafe(
+            db4, fit, fi1, fi2, fi3, extrap)) == 0
+        @test (@allocated EarthSciData.interp_time_only(
+            db4, fit, fi1, fi2, fi3, extrap)) == 0
+
+        # ----- 3D (2 spatial + time) — emissions -----
+        data3 = rand(T, 10, 10, 2)
+        db3 = EarthSciData.DataBufferType(data3)
+        @test @inferred(EarthSciData.interp_unsafe(db3, fit, fi1, fi2, extrap)) isa T
+        @test @inferred(EarthSciData.interp_time_only(db3, fit, fi1, fi2, extrap)) isa T
+        EarthSciData.interp_unsafe(db3, fit, fi1, fi2, extrap)
+        EarthSciData.interp_time_only(db3, fit, fi1, fi2, extrap)
+        @test (@allocated EarthSciData.interp_unsafe(db3, fit, fi1, fi2, extrap)) == 0
+        @test (@allocated EarthSciData.interp_time_only(db3, fit, fi1, fi2, extrap)) == 0
+
+        # ----- 2D (1 spatial + time) -----
+        data2 = rand(T, 10, 2)
+        db2 = EarthSciData.DataBufferType(data2)
+        @test @inferred(EarthSciData.interp_unsafe(db2, fit, fi1, extrap)) isa T
+        @test @inferred(EarthSciData.interp_time_only(db2, fit, fi1, extrap)) isa T
+        EarthSciData.interp_unsafe(db2, fit, fi1, extrap)
+        EarthSciData.interp_time_only(db2, fit, fi1, extrap)
+        @test (@allocated EarthSciData.interp_unsafe(db2, fit, fi1, extrap)) == 0
+        @test (@allocated EarthSciData.interp_time_only(db2, fit, fi1, extrap)) == 0
+    end
+end
+
 @testitem "Float32 DomainInfo → Float32 data buffer (no Float64 promotion)" begin
     using EarthSciData
     using EarthSciMLBase

--- a/test/nei2016monthly_test.jl
+++ b/test/nei2016monthly_test.jl
@@ -48,8 +48,9 @@ end
 
 @testitem "projections" setup=[NEISetup] begin
     import Proj
-    fs = EarthSciData.FileSetWithRegridder(fileset, EarthSciData.regridder(fileset,
-        EarthSciData.loadmetadata(fileset, first(EarthSciData.varnames(fileset))), domain))
+    fs = EarthSciData.FileSetWithRegridder(fileset,
+        EarthSciData.regridder(fileset,
+            EarthSciData.loadmetadata(fileset, first(EarthSciData.varnames(fileset))), domain))
     @testset "correct projection" begin
         itp = EarthSciData.DataSetInterpolator{Float32}(fs, "NOX", ts, te, domain)
         result = interp!(itp, sample_time, deg2rad(-97.0f0), deg2rad(40.0f0))
@@ -106,7 +107,7 @@ end
     prob = ODEProblem(
         sys,
         [lat => deg2rad(40.0), lon => deg2rad(-97.5), lev => 1.0],
-        (0.0, 60.0),
+        (0.0, 60.0)
     )
     solve(prob, Tsit5())
 end
@@ -116,12 +117,12 @@ end
     using ModelingToolkit: t, D
     using DynamicQuantities
     domain = DomainInfo(
-    DateTime(2016, 5, 16),
-    DateTime(2016, 5, 17);
-    lonrange=deg2rad(-125):deg2rad(0.625):deg2rad(-66.875),
-    latrange=deg2rad(25):deg2rad(0.5):deg2rad(49),
-    levrange=1:2,
-    u_proto=zeros(Float64, 1, 1, 1, 1))
+        DateTime(2016, 5, 16),
+        DateTime(2016, 5, 17);
+        lonrange = deg2rad(-125):deg2rad(0.625):deg2rad(-66.875),
+        latrange = deg2rad(25):deg2rad(0.5):deg2rad(49),
+        levrange = 1:2,
+        u_proto = zeros(Float64, 1, 1, 1, 1))
 
     emis_nei = NEI2016MonthlyEmis("mrggrid_withbeis_withrwc", domain)
     @constants uc = 1.0 [unit = u"s" description = "unit conversion"]
@@ -137,7 +138,7 @@ end
     prob = ODEProblem(
         sys,
         [lat_p => deg2rad(40.0), lon_p => deg2rad(-97.5), lev_p => 1.0],
-        (0.0, 60.0),
+        (0.0, 60.0)
     )
     sol = solve(prob, Tsit5())
     @test sol.u[end][end] != 0.0  # Ensure we get a nonzero result
@@ -165,24 +166,28 @@ end
 
     # 6 AM Chicago = 12 PM UTC (6 hours later)
     six_am_chicago = t_ref_numeric + 12 * 3600.0  # 6 AM Chicago = 12 PM UTC, 7th factor
-    @test EarthSciData.diurnal_itp(six_am_chicago, lon_chicago) == EarthSciData.DIURNAL_FACTORS[7]
+    @test EarthSciData.diurnal_itp(six_am_chicago, lon_chicago) ==
+          EarthSciData.DIURNAL_FACTORS[7]
 
     # 6 PM Chicago = 12 AM UTC next day (6 hours later)
     six_pm_chicago = t_ref_numeric + 24 * 3600.0  # 6 PM Chicago = 12 AM UTC next day, 19th factor
-    @test EarthSciData.diurnal_itp(six_pm_chicago, lon_chicago) == EarthSciData.DIURNAL_FACTORS[19]
+    @test EarthSciData.diurnal_itp(six_pm_chicago, lon_chicago) ==
+          EarthSciData.DIURNAL_FACTORS[19]
 
     # Test that the function wraps around 24 hours correctly
     # 24 hours = 86400 seconds
     next_midnight_utc = t_ref_numeric + 24 * 3600.0  # 24 hours since start
-    @test EarthSciData.diurnal_itp(next_midnight_utc, lon_utc) == EarthSciData.DIURNAL_FACTORS[1]
+    @test EarthSciData.diurnal_itp(next_midnight_utc, lon_utc) ==
+          EarthSciData.DIURNAL_FACTORS[1]
 
     # Test fractional hours
     half_past_one_utc = t_ref_numeric + 1.5 * 3600.0  # 1.5 hours since start
-    @test EarthSciData.diurnal_itp(half_past_one_utc, lon_utc) == EarthSciData.DIURNAL_FACTORS[2]  # Should floor to hour 1
+    @test EarthSciData.diurnal_itp(half_past_one_utc, lon_utc) ==
+          EarthSciData.DIURNAL_FACTORS[2]  # Should floor to hour 1
 end
 
 @testitem "allocations" setup=[NEISetup] begin
-     using AllocCheck
+    using AllocCheck
     if !Sys.iswindows() # Allocation tests don't seem to work on windows.
         AllocCheck.@check_allocs checkf(
             itp, t, loc1, loc2) = EarthSciData.interp_unsafe(itp, t, loc1, loc2)
@@ -232,8 +237,10 @@ end
 end
 
 @testitem "delp_dry_surface_itp" setup=[NEISetup] begin
-    @test EarthSciData.delp_dry_surface_itp(deg2rad(-94.375), deg2rad(44.5)) ≈ 14.721285536474896
-    @test EarthSciData.delp_dry_surface_itp(deg2rad(-88.125), deg2rad(42.0)) ≈ 14.8498301901334
+    @test EarthSciData.delp_dry_surface_itp(deg2rad(-94.375), deg2rad(44.5)) ≈
+          14.721285536474896
+    @test EarthSciData.delp_dry_surface_itp(deg2rad(-88.125), deg2rad(42.0)) ≈
+          14.8498301901334
 end
 
 @testitem "conservative regridding" setup=[NEISetup] begin
@@ -242,8 +249,8 @@ end
     domain = DomainInfo(
         DateTime(2016, 5, 1),
         DateTime(2016, 5, 2);
-        lonrange=deg2rad(-125):deg2rad(0.625):deg2rad(-66.875),
-        latrange=deg2rad(25):deg2rad(0.5):deg2rad(49),
+        lonrange = deg2rad(-125):deg2rad(0.625):deg2rad(-66.875),
+        latrange = deg2rad(25):deg2rad(0.5):deg2rad(49),
         levrange = 1:10
     )
     emis = NEI2016MonthlyEmis("mrggrid_withbeis_withrwc", domain)
@@ -254,15 +261,16 @@ end
         domain = DomainInfo(
             DateTime(2016, 5, 16, 12, 0, 0),
             DateTime(2016, 5, 17, 12, 0, 0);
-            lonrange=deg2rad(-125):deg2rad(0.625):deg2rad(-66.875),
-            latrange=deg2rad(25):deg2rad(0.5):deg2rad(49),
+            lonrange = deg2rad(-125):deg2rad(0.625):deg2rad(-66.875),
+            latrange = deg2rad(25):deg2rad(0.5):deg2rad(49),
             levrange = 1:10
         )
         ts, te = get_tspan_datetime(domain)
         fileset = EarthSciData.NEI2016MonthlyEmisFileSet("mrggrid_withbeis_withrwc", ts, te)
         # Use the unified DataSetInterpolator with conservative regridding via regridder()
-        fs = EarthSciData.FileSetWithRegridder(fileset, EarthSciData.regridder(fileset,
-            EarthSciData.loadmetadata(fileset, "NO"), domain))
+        fs = EarthSciData.FileSetWithRegridder(fileset,
+            EarthSciData.regridder(fileset,
+                EarthSciData.loadmetadata(fileset, "NO"), domain))
         itp = EarthSciData.DataSetInterpolator{Float64}(fs, "NO", ts, te, domain)
         @test itp.varname == "NO"
         @test itp.metadata !== nothing
@@ -276,14 +284,15 @@ end
         domain = DomainInfo(
             DateTime(2016, 5, 1),
             DateTime(2016, 5, 2);
-            lonrange=deg2rad(-125):deg2rad(2.5):deg2rad(-66.875),
-            latrange=deg2rad(25):deg2rad(2.0):deg2rad(49),
+            lonrange = deg2rad(-125):deg2rad(2.5):deg2rad(-66.875),
+            latrange = deg2rad(25):deg2rad(2.0):deg2rad(49),
             levrange = 1:10
         )
         ts, te = get_tspan_datetime(domain)
         fileset = EarthSciData.NEI2016MonthlyEmisFileSet("mrggrid_withbeis_withrwc", ts, te)
-        fs = EarthSciData.FileSetWithRegridder(fileset, EarthSciData.regridder(fileset,
-            EarthSciData.loadmetadata(fileset, "NO"), domain))
+        fs = EarthSciData.FileSetWithRegridder(fileset,
+            EarthSciData.regridder(fileset,
+                EarthSciData.loadmetadata(fileset, "NO"), domain))
         itp = EarthSciData.DataSetInterpolator{Float64}(fs, "NO", ts, te, domain)
 
         # Test that interpolation works at a specific location
@@ -300,8 +309,8 @@ end
     domain = DomainInfo(
         DateTime(2016, 5, 15),
         DateTime(2016, 5, 16);
-        lonrange=deg2rad(-88.125):deg2rad(0.625):deg2rad(-86.875),
-        latrange=deg2rad(42):deg2rad(0.5):deg2rad(43),
+        lonrange = deg2rad(-88.125):deg2rad(0.625):deg2rad(-86.875),
+        latrange = deg2rad(42):deg2rad(0.5):deg2rad(43),
         levrange = 1:2
     )
     emis = NEI2016MonthlyEmis("mrggrid_withbeis_withrwc", domain)
@@ -321,7 +330,7 @@ end
     @constants uc = 1.0 [unit = u"s", description = "unit conversion"]
     @variables NO(t) = 0.0 [unit = u"1/s"]
 
-    saveat = range(tspan[1], tspan[2], length=nt)
+    saveat = range(tspan[1], tspan[2], length = nt)
 
     for (i, lon_val) in enumerate(lon_grid)
         for (j, lat_val) in enumerate(lat_grid)
@@ -338,7 +347,7 @@ end
                 [lat_p => lat_val, lon_p => lon_val, lev_p => 1.0],
                 tspan)
 
-            sol = solve(prob, Tsit5(), saveat=saveat)
+            sol = solve(prob, Tsit5(), saveat = saveat)
             NO_map[i, j, :] = getindex.(sol.u, 1)
         end
     end
@@ -354,8 +363,8 @@ end
     domain = DomainInfo(
         DateTime(2016, 5, 15),
         DateTime(2016, 5, 16);
-        lonrange=deg2rad(-88.125):deg2rad(0.625):deg2rad(-86.875),
-        latrange=deg2rad(42):deg2rad(0.5):deg2rad(43),
+        lonrange = deg2rad(-88.125):deg2rad(0.625):deg2rad(-86.875),
+        latrange = deg2rad(42):deg2rad(0.5):deg2rad(43),
         levrange = 1:2
     )
     emis = NEI2016MonthlyEmis("mrggrid_withbeis_withrwc", domain)
@@ -372,12 +381,14 @@ end
     @constants uc = 1.0 [unit = u"s", description = "unit conversion"]
     @variables ACET(t) = 0.0 [unit = u"1/s"]
 
-    saveat = range(tspan[1], tspan[2], length=nt)
+    saveat = range(tspan[1], tspan[2], length = nt)
 
     for (i, lon_val) in enumerate(lon_grid)
         for (j, lat_val) in enumerate(lat_grid)
             eq = D(ACET) ~ emis.ACET / uc
-            sys = compose(System([eq], t, [ACET], [uc]; name = Symbol("ACET_sys_$(i)_$(j)")), emis)
+            sys = compose(
+                System(
+                    [eq], t, [ACET], [uc]; name = Symbol("ACET_sys_$(i)_$(j)")), emis)
             sys = mtkcompile(sys)
             # After composition, parameters are namespaced; extract them from the compiled system
             ps = parameters(sys)
@@ -389,7 +400,7 @@ end
                 [lat_p => lat_val, lon_p => lon_val, lev_p => 1.0],
                 tspan)
 
-            sol = solve(prob, Tsit5(), saveat=saveat)
+            sol = solve(prob, Tsit5(), saveat = saveat)
             ACET_map[i, j, :] = getindex.(sol.u, 1)
         end
     end

--- a/test/nei2016monthly_test.jl
+++ b/test/nei2016monthly_test.jl
@@ -197,30 +197,29 @@ end
 @testitem "allocations" setup=[NEISetup] begin
     using AllocCheck
     if !Sys.iswindows() # Allocation tests don't seem to work on windows.
+        # Verify that the MTK-hot-path `interp_unsafe(data::DataBufferType,
+        # fit, fi1, fi2, extrap)` is statically allocation-free. This is
+        # the exact entry point used by the RHS function that MTK generates;
+        # everything else (coordinate-to-index conversion, DateTime to unix,
+        # etc.) is folded into the symbolic equation at codegen time, so the
+        # runtime call receives pre-computed fractional indices.
         AllocCheck.@check_allocs checkf(
-            itp, t, loc1, loc2) = EarthSciData.interp_unsafe(itp, t, loc1, loc2)
+            db, fit, fi1, fi2, extrap) = EarthSciData.interp_unsafe(
+            db, fit, fi1, fi2, extrap)
 
-        sample_time = DateTime(2016, 5, 1)
-        itp = EarthSciData.DataSetInterpolator{Float32}(fileset, "NOX", ts, te, domain)
-        interp!(itp, sample_time, deg2rad(-97.0f0), deg2rad(40.0f0))
-        # If there is an error, it should occur in the proj library.
-        # https://github.com/JuliaGeo/Proj.jl/issues/104
-        try
-            checkf(itp, sample_time, deg2rad(-97.0f0), deg2rad(40.0f0))
-        catch err
-            @warn "Allocation errors:\n$(err.errors)"
-            @test length(err.errors) <= 3
-            @test all([contains(string(s), "jl_get_pgcstack_static") for s in err.errors])
-        end
-
-        itp2 = EarthSciData.DataSetInterpolator{Float64}(fileset, "NOX", ts, te, domain)
-        interp!(itp2, sample_time, deg2rad(-97.0), deg2rad(40.0))
-        try # If there is an error, it should occur in the proj library.
-            checkf(itp2, sample_time, deg2rad(-97.0), deg2rad(40.0))
-        catch err
-            @warn "Allocation errors:\n$(err.errors)"
-            @test length(err.errors) <= 3
-            @test all([contains(string(s), "jl_get_pgcstack_static") for s in err.errors])
+        for T in (Float32, Float64)
+            sample_time = DateTime(2016, 5, 1)
+            itp = EarthSciData.DataSetInterpolator{T}(fileset, "NOX", ts, te, domain)
+            EarthSciData.lazyload!(itp, sample_time)
+            db = EarthSciData.DataBufferType(itp.cache.data_buffer)
+            # Warm up then check: no catch needed — this MUST be alloc-free.
+            checkf(db, T(1.5), T(5.3), T(5.7), T(1.0))
+            try
+                checkf(db, T(1.5), T(5.3), T(5.7), T(1.0))
+            catch err
+                @warn "Allocation errors ($T):\n$(err.errors)"
+                @test length(err.errors) == 0
+            end
         end
     end
 end
@@ -356,7 +355,10 @@ end
                 tspan)
 
             sol = solve(prob, Tsit5(), saveat = saveat)
-            NO_map[i, j, :] = getindex.(sol.u, 1)
+            # Use the interpolant: the data-update discrete callback fires at
+            # tspan[1] and `save_positions=(true,true)` adds an extra entry
+            # at t=0, so `length(sol.u)` may exceed `length(saveat)`.
+            NO_map[i, j, :] = [u[1] for u in sol(saveat).u]
         end
     end
 
@@ -409,7 +411,10 @@ end
                 tspan)
 
             sol = solve(prob, Tsit5(), saveat = saveat)
-            ACET_map[i, j, :] = getindex.(sol.u, 1)
+            # Use the interpolant: the data-update discrete callback fires at
+            # tspan[1] and `save_positions=(true,true)` adds an extra entry
+            # at t=0, so `length(sol.u)` may exceed `length(saveat)`.
+            ACET_map[i, j, :] = [u[1] for u in sol(saveat).u]
         end
     end
 

--- a/test/nei2016monthly_test.jl
+++ b/test/nei2016monthly_test.jl
@@ -102,11 +102,19 @@ end
 
 @testitem "run" setup=[NEISetup] begin
     using ModelingToolkit
+    using ModelingToolkit: t, D
     using OrdinaryDiffEqTsit5
-    sys = mtkcompile(emis)
+
+    # NEI has no state variables; wrap with a trivial dummy to satisfy
+    # the ODE solver (same pattern as the GEOSFP/WRF/NCEP/EDGAR tests).
+    @variables _dummy(t) = 0.0
+    _sys = compose(System([D(_dummy) ~ 0], t; name = :_w), emis)
+    sys = mtkcompile(_sys)
     prob = ODEProblem(
         sys,
-        [lat => deg2rad(40.0), lon => deg2rad(-97.5), lev => 1.0],
+        [sys.NEI2016MonthlyEmis.lat => deg2rad(40.0),
+            sys.NEI2016MonthlyEmis.lon => deg2rad(-97.5),
+            sys.NEI2016MonthlyEmis.lev => 1.0],
         (0.0, 60.0)
     )
     solve(prob, Tsit5())

--- a/test/openaq_test.jl
+++ b/test/openaq_test.jl
@@ -33,7 +33,7 @@ end
         EarthSciData.OpenAQStation(1, "A", deg2rad(-73.0), deg2rad(40.0)),
         EarthSciData.OpenAQStation(2, "B", deg2rad(-73.5), deg2rad(40.5)),
         EarthSciData.OpenAQStation(3, "C", deg2rad(-73.0), deg2rad(40.0)),  # Same cell as A
-        EarthSciData.OpenAQStation(4, "D", deg2rad(-100.0), deg2rad(20.0)), # Outside grid
+        EarthSciData.OpenAQStation(4, "D", deg2rad(-100.0), deg2rad(20.0)) # Outside grid
     ]
 
     # Grid edges in radians: 2 cells in each direction
@@ -72,10 +72,13 @@ end
 @testitem "S3 URL construction" setup=[OpenAQSetup] begin
     d = Date(2024, 3, 15)
     url = EarthSciData._s3_url(12345, d)
-    @test url == "https://openaq-data-archive.s3.amazonaws.com/records/csv.gz/locationid=12345/year=2024/month=03/location-12345-20240315.csv.gz"
+    @test url ==
+          "https://openaq-data-archive.s3.amazonaws.com/records/csv.gz/locationid=12345/year=2024/month=03/location-12345-20240315.csv.gz"
 
     path = EarthSciData._s3_localpath(12345, d)
-    @test endswith(path, joinpath("openaq_data", "locationid=12345", "year=2024", "month=03", "location-12345-20240315.csv.gz"))
+    @test endswith(path,
+        joinpath("openaq_data", "locationid=12345", "year=2024",
+            "month=03", "location-12345-20240315.csv.gz"))
 end
 
 @testitem "loadmetadata" setup=[OpenAQSetup] begin
@@ -84,14 +87,14 @@ end
     lat_edges = deg2rad.([39.0, 40.0, 41.0])
     freq_info = EarthSciData.DataFrequencyInfo(
         DateTime(2024, 1, 1), Hour(1),
-        collect(DateTime(2024, 1, 1):Hour(1):DateTime(2024, 1, 2)),
+        collect(DateTime(2024, 1, 1):Hour(1):DateTime(2024, 1, 2))
     )
     fs = EarthSciData.OpenAQFileSet(
         "pm25", stations, freq_info,
         collect(lon_edges), collect(lat_edges), NaN, 1e-6,
-        Dict{Tuple{Int,Int}, Vector{Int}}(),
+        Dict{Tuple{Int, Int}, Vector{Int}}(),
         Dict{Tuple{Int, Date}, Vector{Tuple{DateTime, Float64}}}(),
-        ReentrantLock(),
+        ReentrantLock()
     )
 
     md = EarthSciData.loadmetadata(fs, "pm25")
@@ -116,7 +119,7 @@ end
     stations = [
         EarthSciData.OpenAQStation(1001, "StationA", deg2rad(-73.5), deg2rad(40.2)),
         EarthSciData.OpenAQStation(1002, "StationB", deg2rad(-73.5), deg2rad(40.2)),
-        EarthSciData.OpenAQStation(1003, "StationC", deg2rad(-72.5), deg2rad(40.8)),
+        EarthSciData.OpenAQStation(1003, "StationC", deg2rad(-72.5), deg2rad(40.8))
     ]
 
     d = Date(2024, 6, 15)
@@ -149,7 +152,7 @@ end
 
     freq_info = EarthSciData.DataFrequencyInfo(
         DateTime(2024, 6, 15), Hour(1),
-        collect(DateTime(2024, 6, 15):Hour(1):DateTime(2024, 6, 16)),
+        collect(DateTime(2024, 6, 15):Hour(1):DateTime(2024, 6, 16))
     )
 
     cell_stations = EarthSciData._build_cell_station_map(stations, collect(lon_edges), collect(lat_edges))
@@ -158,7 +161,7 @@ end
         collect(lon_edges), collect(lat_edges), NaN, 1e-6,
         cell_stations,
         Dict{Tuple{Int, Date}, Vector{Tuple{DateTime, Float64}}}(),
-        ReentrantLock(),
+        ReentrantLock()
     )
 
     data = zeros(Float64, 2, 2)
@@ -186,7 +189,7 @@ end
         collect(lon_edges), collect(lat_edges), 0.0, 1e-6,
         cell_stations,
         Dict{Tuple{Int, Date}, Vector{Tuple{DateTime, Float64}}}(),
-        ReentrantLock(),
+        ReentrantLock()
     )
     data2 = zeros(Float64, 2, 2)
     EarthSciData.loadslice!(data2, fs_zero, DateTime(2024, 6, 15, 12), "pm25")
@@ -200,14 +203,14 @@ end
     stations = EarthSciData.OpenAQStation[]
     freq_info = EarthSciData.DataFrequencyInfo(
         DateTime(2024, 1, 1), Hour(1),
-        collect(DateTime(2024, 1, 1):Hour(1):DateTime(2024, 1, 2)),
+        collect(DateTime(2024, 1, 1):Hour(1):DateTime(2024, 1, 2))
     )
     fs = EarthSciData.OpenAQFileSet(
         "o3", stations, freq_info,
         [0.0, 1.0], [0.0, 1.0], NaN, 1e-6,
-        Dict{Tuple{Int,Int}, Vector{Int}}(),
+        Dict{Tuple{Int, Int}, Vector{Int}}(),
         Dict{Tuple{Int, Date}, Vector{Tuple{DateTime, Float64}}}(),
-        ReentrantLock(),
+        ReentrantLock()
     )
     @test EarthSciData.varnames(fs) == ["o3"]
 end
@@ -216,16 +219,16 @@ end
     stations = EarthSciData.OpenAQStation[]
     freq_info = EarthSciData.DataFrequencyInfo(
         DateTime(2024, 1, 1), Hour(1),
-        collect(DateTime(2024, 1, 1):Hour(1):DateTime(2024, 1, 2)),
+        collect(DateTime(2024, 1, 1):Hour(1):DateTime(2024, 1, 2))
     )
     lon_edges = [0.0, 1.0, 2.0]
     lat_edges = [0.0, 1.0, 2.0]
     fs = EarthSciData.OpenAQFileSet(
         "pm25", stations, freq_info,
         lon_edges, lat_edges, NaN, 1e-6,
-        Dict{Tuple{Int,Int}, Vector{Int}}(),
+        Dict{Tuple{Int, Int}, Vector{Int}}(),
         Dict{Tuple{Int, Date}, Vector{Tuple{DateTime, Float64}}}(),
-        ReentrantLock(),
+        ReentrantLock()
     )
     md = EarthSciData.loadmetadata(fs, "pm25")
     polys = EarthSciData.get_geometry(fs, md)
@@ -242,13 +245,16 @@ end
     # Create a fake cached station JSON file with 3 stations
     cache_dir = joinpath(tmpdir, "openaq_stations")
     mkpath(cache_dir)
-    bbox = (lon_min=-74.0, lat_min=39.0, lon_max=-72.0, lat_max=41.0)
+    bbox = (lon_min = -74.0, lat_min = 39.0, lon_max = -72.0, lat_max = 41.0)
     bbox_str = "$(bbox.lon_min)_$(bbox.lat_min)_$(bbox.lon_max)_$(bbox.lat_max)"
     cache_file = joinpath(cache_dir, "pm25_$(bbox_str).json")
     raw_stations = [
-        Dict("id" => 1, "name" => "Good Station", "coordinates" => Dict("longitude" => -73.0, "latitude" => 40.0)),
-        Dict("id" => 2, "name" => "Bad Station", "coordinates" => Dict("longitude" => -73.5, "latitude" => 40.5)),
-        Dict("id" => 3, "name" => "Good Station 2", "coordinates" => Dict("longitude" => -72.5, "latitude" => 40.8)),
+        Dict("id" => 1, "name" => "Good Station",
+            "coordinates" => Dict("longitude" => -73.0, "latitude" => 40.0)),
+        Dict("id" => 2, "name" => "Bad Station",
+            "coordinates" => Dict("longitude" => -73.5, "latitude" => 40.5)),
+        Dict("id" => 3, "name" => "Good Station 2",
+            "coordinates" => Dict("longitude" => -72.5, "latitude" => 40.8))
     ]
     open(cache_file, "w") do io
         JSON3.write(io, raw_stations)
@@ -261,7 +267,7 @@ end
     # Test with filter: exclude "Bad Station"
     stations_filtered = EarthSciData.discover_stations(
         "pm25", bbox, "fake_key",
-        s -> !occursin("Bad", s.name),
+        s -> !occursin("Bad", s.name)
     )
     @test length(stations_filtered) == 2
     @test all(s -> !occursin("Bad", s.name), stations_filtered)
@@ -310,7 +316,7 @@ end
 
     freq_info = EarthSciData.DataFrequencyInfo(
         DateTime(2024, 6, 15), Hour(1),
-        collect(DateTime(2024, 6, 15):Hour(1):DateTime(2024, 6, 16)),
+        collect(DateTime(2024, 6, 15):Hour(1):DateTime(2024, 6, 16))
     )
 
     cell_stations = EarthSciData._build_cell_station_map(stations, collect(lon_edges), collect(lat_edges))
@@ -319,7 +325,7 @@ end
         collect(lon_edges), collect(lat_edges), NaN, 1e-6,
         cell_stations,
         Dict{Tuple{Int, Date}, Vector{Tuple{DateTime, Float64}}}(),
-        ReentrantLock(),
+        ReentrantLock()
     )
 
     # At hour 12 UTC: should get average of 100.0 and 200.0 (the +05:30 values mapped to UTC 12:00 and 12:30)
@@ -362,7 +368,7 @@ end
     lat_edges = deg2rad.([39.5, 40.5])
     freq_info = EarthSciData.DataFrequencyInfo(
         DateTime(2024, 6, 15), Hour(1),
-        collect(DateTime(2024, 6, 15):Hour(1):DateTime(2024, 6, 16)),
+        collect(DateTime(2024, 6, 15):Hour(1):DateTime(2024, 6, 16))
     )
     cell_stations = EarthSciData._build_cell_station_map(stations, collect(lon_edges), collect(lat_edges))
 
@@ -372,7 +378,7 @@ end
         collect(lon_edges), collect(lat_edges), NaN, 1e-6,
         cell_stations,
         Dict{Tuple{Int, Date}, Vector{Tuple{DateTime, Float64}}}(),
-        ReentrantLock(),
+        ReentrantLock()
     )
     data = zeros(Float64, 1, 1)
     EarthSciData.loadslice!(data, fs_pm25, DateTime(2024, 6, 15, 12), "pm25")
@@ -384,7 +390,7 @@ end
         collect(lon_edges), collect(lat_edges), NaN, 1e-6,
         cell_stations,
         Dict{Tuple{Int, Date}, Vector{Tuple{DateTime, Float64}}}(),
-        ReentrantLock(),
+        ReentrantLock()
     )
     data_o3 = zeros(Float64, 1, 1)
     EarthSciData.loadslice!(data_o3, fs_o3, DateTime(2024, 6, 15, 12), "o3")
@@ -405,15 +411,15 @@ end
         EarthSciData.OpenAQStation(4001, "SW", deg2rad(-73.5), deg2rad(40.0)),
         EarthSciData.OpenAQStation(4002, "NW", deg2rad(-73.5), deg2rad(40.7)),
         EarthSciData.OpenAQStation(4003, "SE", deg2rad(-72.5), deg2rad(40.0)),
-        EarthSciData.OpenAQStation(4004, "NE", deg2rad(-72.5), deg2rad(40.7)),
+        EarthSciData.OpenAQStation(4004, "NE", deg2rad(-72.5), deg2rad(40.7))
     ]
 
     d = Date(2024, 6, 15)
     csv_header = "location_id,sensor_id,location,datetime,lat,lon,parameter,unit,value"
 
     # All stations report the same values so interpolation result is uniform
-    for (id, name, lat, lon) in [(4001,"SW",40.0,-73.5), (4002,"NW",40.7,-73.5),
-                                  (4003,"SE",40.0,-72.5), (4004,"NE",40.7,-72.5)]
+    for (id, name, lat, lon) in [(4001, "SW", 40.0, -73.5), (4002, "NW", 40.7, -73.5),
+        (4003, "SE", 40.0, -72.5), (4004, "NE", 40.7, -72.5)]
         csv_content = """$csv_header
 $id,8001,$name,2024-06-15T12:00:00+00:00,$lat,$lon,pm25,µg/m³,100.0
 $id,8001,$name,2024-06-15T13:00:00+00:00,$lat,$lon,pm25,µg/m³,200.0
@@ -430,7 +436,7 @@ $id,8001,$name,2024-06-15T14:00:00+00:00,$lat,$lon,pm25,µg/m³,300.0"""
     lat_edges = deg2rad.([39.5, 40.5, 41.0])
     freq_info = EarthSciData.DataFrequencyInfo(
         DateTime(2024, 6, 15), Hour(1),
-        collect(DateTime(2024, 6, 15):Hour(1):DateTime(2024, 6, 16)),
+        collect(DateTime(2024, 6, 15):Hour(1):DateTime(2024, 6, 16))
     )
     cell_stations = EarthSciData._build_cell_station_map(stations, collect(lon_edges), collect(lat_edges))
     fs = EarthSciData.OpenAQFileSet(
@@ -438,7 +444,7 @@ $id,8001,$name,2024-06-15T14:00:00+00:00,$lat,$lon,pm25,µg/m³,300.0"""
         collect(lon_edges), collect(lat_edges), NaN, 1e-6,
         cell_stations,
         Dict{Tuple{Int, Date}, Vector{Tuple{DateTime, Float64}}}(),
-        ReentrantLock(),
+        ReentrantLock()
     )
 
     # Create a DomainInfo matching our 2x2 grid
@@ -447,7 +453,7 @@ $id,8001,$name,2024-06-15T14:00:00+00:00,$lat,$lon,pm25,µg/m³,300.0"""
         DateTime(2024, 6, 15, 15);
         lonrange = deg2rad(-74.0):deg2rad(1.0):deg2rad(-72.0),
         latrange = deg2rad(39.5):deg2rad(0.75):deg2rad(41.0),
-        levrange = 1:1,
+        levrange = 1:1
     )
     starttime, endtime = get_tspan_datetime(domain)
 
@@ -482,7 +488,7 @@ end
         DateTime(2024, 6, 15, 14);
         lonrange = deg2rad(lon_min):deg2rad(1.0):deg2rad(lon_max),
         latrange = deg2rad(lat_min):deg2rad(1.0):deg2rad(lat_max),
-        levrange = 1:1,
+        levrange = 1:1
     )
 
     # The OpenAQ constructor computes bbox from grid edges, which uses staggered=true.
@@ -499,7 +505,8 @@ end
     cache_file = joinpath(cache_dir, "pm25_$(bbox_str).json")
 
     raw_stations = [
-        Dict("id" => 5001, "name" => "TestStation", "coordinates" => Dict("longitude" => -73.0, "latitude" => 40.0)),
+        Dict("id" => 5001, "name" => "TestStation",
+        "coordinates" => Dict("longitude" => -73.0, "latitude" => 40.0)),
     ]
     open(cache_file, "w") do io
         JSON3.write(io, raw_stations)
@@ -519,7 +526,7 @@ end
     end
 
     # Call the actual OpenAQ() constructor
-    sys = OpenAQ("pm25", domain; api_key="fake_key_for_test")
+    sys = OpenAQ("pm25", domain; api_key = "fake_key_for_test")
 
     # Verify it returns a System with expected structure
     @test sys isa ModelingToolkit.System

--- a/test/openaq_test.jl
+++ b/test/openaq_test.jl
@@ -460,13 +460,13 @@ $id,8001,$name,2024-06-15T14:00:00+00:00,$lat,$lon,pm25,µg/m³,300.0"""
     itp = EarthSciData.DataSetInterpolator{Float64}(fs, "pm25", starttime, endtime, domain)
 
     # Interpolate at grid center at hour 12: all stations report 100 µg/m³ = 100e-6 kg/m³
-    result = EarthSciData.interp(itp, DateTime(2024, 6, 15, 12),
+    result = EarthSciData.interp!(itp, DateTime(2024, 6, 15, 12),
         deg2rad(-73.5), deg2rad(40.0))
     @test result > 0
     @test result ≈ 100.0e-6 rtol=0.5
 
     # Interpolate at hour 13: all stations report 200 µg/m³
-    result2 = EarthSciData.interp(itp, DateTime(2024, 6, 15, 13),
+    result2 = EarthSciData.interp!(itp, DateTime(2024, 6, 15, 13),
         deg2rad(-73.5), deg2rad(40.0))
     @test result2 > result  # Should increase over time
 

--- a/test/regridding.jl
+++ b/test/regridding.jl
@@ -1,10 +1,10 @@
 
 @testitem "data2vecormat" begin
-    d = zeros(1,2,3)
+    d = zeros(1, 2, 3)
     d2 = EarthSciData.data2vecormat(d, 2, 3)
-    @test size(d2) == (6,1)
+    @test size(d2) == (6, 1)
 
-    d = zeros(2,3)
+    d = zeros(2, 3)
     d2 = EarthSciData.data2vecormat(d, 2, 1)
     @test size(d2) == (6,)
 end

--- a/test/solve_test.jl
+++ b/test/solve_test.jl
@@ -1,4 +1,5 @@
 @testsnippet SolveSetup begin
+    using EarthSciData
     using EarthSciMLBase, ModelingToolkit
     using ModelingToolkit: t, D
     using Dates

--- a/test/solve_test.jl
+++ b/test/solve_test.jl
@@ -66,4 +66,3 @@ end
     sol = solve(prob, KenCarp3())
     @test sum(sol.u[end]) ≈ 1.824462850685205e-5 rtol = 0.15
 end
-

--- a/test/usgs3dep_test.jl
+++ b/test/usgs3dep_test.jl
@@ -8,14 +8,14 @@
     domain = DomainInfo(
         DateTime(2018, 11, 8),
         DateTime(2018, 11, 9);
-        lonrange=deg2rad(-121.65):deg2rad(0.01):deg2rad(-121.55),
-        latrange=deg2rad(39.73):deg2rad(0.01):deg2rad(39.83),
-        levrange=1:1,
+        lonrange = deg2rad(-121.65):deg2rad(0.01):deg2rad(-121.55),
+        latrange = deg2rad(39.73):deg2rad(0.01):deg2rad(39.83),
+        levrange = 1:1
     )
 end
 
-@testitem "USGS3DEP FileSet construction" setup = [USGS3DEPSetup] tags = [:usgs3dep] begin
-    fs = EarthSciData.USGS3DEPFileSet(domain)
+@testitem "USGS3DEP FileSet construction" setup=[USGS3DEPSetup] tags=[:usgs3dep] begin
+    fs=EarthSciData.USGS3DEPFileSet(domain)
     @test EarthSciData.varnames(fs) == ["elevation"]
     @test fs.width > 0
     @test fs.height > 0
@@ -26,27 +26,28 @@ end
     @test fs.bbox[4] >= 39.83
 end
 
-@testitem "USGS3DEP offline structural tests" setup = [USGS3DEPSetup] tags = [:usgs3dep] begin
+@testitem "USGS3DEP offline structural tests" setup=[USGS3DEPSetup] tags=[:usgs3dep] begin
     # These tests verify FileSet construction, metadata, and URL generation
     # without any network access.
-    fs = EarthSciData.USGS3DEPFileSet(domain; resolution=10.0)
+    fs=EarthSciData.USGS3DEPFileSet(domain; resolution = 10.0)
 
     # URL format
-    u = EarthSciData.url(fs, DateTime(2018, 11, 8))
-    @test startswith(u, "https://elevation.nationalmap.gov/arcgis/rest/services/3DEPElevation/ImageServer/exportImage?")
+    u=EarthSciData.url(fs, DateTime(2018, 11, 8))
+    @test startswith(u,
+        "https://elevation.nationalmap.gov/arcgis/rest/services/3DEPElevation/ImageServer/exportImage?")
     @test occursin("bbox=", u)
     @test occursin("bboxSR=4326", u)
     @test occursin("format=tiff", u)
     @test occursin("pixelType=F32", u)
 
     # relpath encodes bbox and dimensions
-    rp = EarthSciData.relpath(fs, DateTime(2018, 11, 8))
+    rp=EarthSciData.relpath(fs, DateTime(2018, 11, 8))
     @test startswith(rp, "usgs3dep/elevation_")
     @test endswith(rp, ".tif")
     @test occursin("$(fs.width)x$(fs.height)", rp)
 
     # Metadata (computed from bbox, no download needed)
-    md = EarthSciData.loadmetadata(fs, "elevation")
+    md=EarthSciData.loadmetadata(fs, "elevation")
     @test md.unit_str == "m"
     @test md.description == "Terrain elevation above sea level"
     @test md.xdim == 1
@@ -65,7 +66,7 @@ end
     @test rad2deg(last(md.coords[2])) < fs.bbox[4]
 
     # Pixel clamping: very fine resolution should hit the 1000-pixel cap
-    fs_fine = EarthSciData.USGS3DEPFileSet(domain; resolution=0.001)
+    fs_fine=EarthSciData.USGS3DEPFileSet(domain; resolution = 0.001)
     @test fs_fine.width == 1000
     @test fs_fine.height == 1000
 
@@ -73,18 +74,18 @@ end
     @test_throws AssertionError EarthSciData.loadmetadata(fs, "temperature")
 
     # Out-of-coverage domain should warn
-    eu_domain = DomainInfo(
+    eu_domain=DomainInfo(
         DateTime(2018, 11, 8), DateTime(2018, 11, 9);
-        lonrange=deg2rad(10.0):deg2rad(0.1):deg2rad(11.0),
-        latrange=deg2rad(48.0):deg2rad(0.1):deg2rad(49.0),
-        levrange=1:1,
+        lonrange = deg2rad(10.0):deg2rad(0.1):deg2rad(11.0),
+        latrange = deg2rad(48.0):deg2rad(0.1):deg2rad(49.0),
+        levrange = 1:1
     )
     @test_warn "outside USGS 3DEP coverage" EarthSciData.USGS3DEPFileSet(eu_domain)
 end
 
-@testitem "USGS3DEP metadata" setup = [USGS3DEPSetup] tags = [:usgs3dep] begin
-    fs = EarthSciData.USGS3DEPFileSet(domain; resolution=10.0)  # coarse for speed
-    md = EarthSciData.loadmetadata(fs, "elevation")
+@testitem "USGS3DEP metadata" setup=[USGS3DEPSetup] tags=[:usgs3dep] begin
+    fs=EarthSciData.USGS3DEPFileSet(domain; resolution = 10.0)  # coarse for speed
+    md=EarthSciData.loadmetadata(fs, "elevation")
     @test md.unit_str == "m"
     @test md.description == "Terrain elevation above sea level"
     @test length(md.coords) == 2
@@ -99,39 +100,39 @@ end
     @test issorted(md.coords[2])
 end
 
-@testitem "USGS3DEP data loading" setup = [USGS3DEPSetup] tags = [:usgs3dep] begin
-    fs = EarthSciData.USGS3DEPFileSet(domain; resolution=10.0)
-    md = EarthSciData.loadmetadata(fs, "elevation")
-    data = zeros(Float32, md.varsize...)
-    ts, _ = EarthSciMLBase.get_tspan_datetime(domain)
+@testitem "USGS3DEP data loading" setup=[USGS3DEPSetup] tags=[:usgs3dep] begin
+    fs=EarthSciData.USGS3DEPFileSet(domain; resolution = 10.0)
+    md=EarthSciData.loadmetadata(fs, "elevation")
+    data=zeros(Float32, md.varsize...)
+    ts, _=EarthSciMLBase.get_tspan_datetime(domain)
     EarthSciData.loadslice!(data, fs, ts, "elevation")
     # Paradise area elevation should be roughly 100-1000m
-    valid = data[data.>0]
+    valid=data[data .> 0]
     # At least 90% of pixels should have valid elevation data
     @test length(valid) / length(data) > 0.9
     @test minimum(valid) > 50
     @test maximum(data) < 3000
 end
 
-@testitem "USGS3DEP interpolator" setup = [USGS3DEPSetup] tags = [:usgs3dep] begin
-    fs = EarthSciData.USGS3DEPFileSet(domain; resolution=10.0)
-    ts, te = EarthSciMLBase.get_tspan_datetime(domain)
-    itp = EarthSciData.DataSetInterpolator{Float32}(
-        fs, "elevation", ts, te, domain; stream=true)
+@testitem "USGS3DEP interpolator" setup=[USGS3DEPSetup] tags=[:usgs3dep] begin
+    fs=EarthSciData.USGS3DEPFileSet(domain; resolution = 10.0)
+    ts, te=EarthSciMLBase.get_tspan_datetime(domain)
+    itp=EarthSciData.DataSetInterpolator{Float32}(
+        fs, "elevation", ts, te, domain; stream = true)
     # Interpolate at the centre of the domain
-    lon_c = deg2rad(-121.60)
-    lat_c = deg2rad(39.78)
-    val = EarthSciData.interp(itp, ts, Float32(lon_c), Float32(lat_c))
+    lon_c=deg2rad(-121.60)
+    lat_c=deg2rad(39.78)
+    val=EarthSciData.interp(itp, ts, Float32(lon_c), Float32(lat_c))
     @test 50 < val < 3000
 end
 
-@testitem "USGS3DEP slope FileSet structural" setup = [USGS3DEPSetup] tags = [:usgs3dep] begin
-    fs = EarthSciData.USGS3DEPFileSet(domain; resolution=10.0)
+@testitem "USGS3DEP slope FileSet structural" setup=[USGS3DEPSetup] tags=[:usgs3dep] begin
+    fs=EarthSciData.USGS3DEPFileSet(domain; resolution = 10.0)
 
     # dzdx
-    slope_x = EarthSciData.USGS3DEPSlopeFileSet(fs, :dzdx)
+    slope_x=EarthSciData.USGS3DEPSlopeFileSet(fs, :dzdx)
     @test EarthSciData.varnames(slope_x) == ["dzdx"]
-    md_x = EarthSciData.loadmetadata(slope_x, "dzdx")
+    md_x=EarthSciData.loadmetadata(slope_x, "dzdx")
     @test md_x.unit_str == "1"
     @test md_x.varsize == [fs.width, fs.height]
     @test occursin("east", md_x.description)
@@ -140,24 +141,24 @@ end
           EarthSciData.relpath(fs, DateTime(2018, 11, 8))
 
     # dzdy
-    slope_y = EarthSciData.USGS3DEPSlopeFileSet(fs, :dzdy)
+    slope_y=EarthSciData.USGS3DEPSlopeFileSet(fs, :dzdy)
     @test EarthSciData.varnames(slope_y) == ["dzdy"]
-    md_y = EarthSciData.loadmetadata(slope_y, "dzdy")
+    md_y=EarthSciData.loadmetadata(slope_y, "dzdy")
     @test md_y.unit_str == "1"
     @test occursin("north", md_y.description)
 end
 
-@testitem "USGS3DEP slope data loading" setup = [USGS3DEPSetup] tags = [:usgs3dep] begin
-    fs = EarthSciData.USGS3DEPFileSet(domain; resolution=10.0)
-    md = EarthSciData.loadmetadata(fs, "elevation")
-    ts, _ = EarthSciMLBase.get_tspan_datetime(domain)
+@testitem "USGS3DEP slope data loading" setup=[USGS3DEPSetup] tags=[:usgs3dep] begin
+    fs=EarthSciData.USGS3DEPFileSet(domain; resolution = 10.0)
+    md=EarthSciData.loadmetadata(fs, "elevation")
+    ts, _=EarthSciMLBase.get_tspan_datetime(domain)
 
-    dzdx = zeros(Float64, md.varsize...)
-    slope_x = EarthSciData.USGS3DEPSlopeFileSet(fs, :dzdx)
+    dzdx=zeros(Float64, md.varsize...)
+    slope_x=EarthSciData.USGS3DEPSlopeFileSet(fs, :dzdx)
     EarthSciData.loadslice!(dzdx, slope_x, ts, "dzdx")
 
-    dzdy = zeros(Float64, md.varsize...)
-    slope_y = EarthSciData.USGS3DEPSlopeFileSet(fs, :dzdy)
+    dzdy=zeros(Float64, md.varsize...)
+    slope_y=EarthSciData.USGS3DEPSlopeFileSet(fs, :dzdy)
     EarthSciData.loadslice!(dzdy, slope_y, ts, "dzdy")
 
     # Slopes should be finite and physically reasonable
@@ -170,85 +171,85 @@ end
     @test maximum(abs, dzdy) < 10.0
 
     # Combined slope magnitude
-    tanphi = sqrt.(dzdx .^ 2 .+ dzdy .^ 2)
+    tanphi=sqrt.(dzdx .^ 2 .+ dzdy .^ 2)
     @test maximum(tanphi) > 0.01  # mountainous terrain has noticeable slope
     @test maximum(tanphi) < 10.0
 end
 
-@testitem "USGS3DEP slope analytical test" setup = [USGS3DEPSetup] tags = [:usgs3dep] begin
+@testitem "USGS3DEP slope analytical test" setup=[USGS3DEPSetup] tags=[:usgs3dep] begin
     # Verify slope computation against synthetic elevation ramps.
     # Test each direction independently to avoid cross-terms from
     # the latitude-dependent metric in the x direction.
-    fs = EarthSciData.USGS3DEPFileSet(domain; resolution=10.0)
-    md = EarthSciData.loadmetadata(fs, "elevation")
-    nlon, nlat = md.varsize
-    lons_rad = md.coords[1]
-    lats_rad = md.coords[2]
+    fs=EarthSciData.USGS3DEPFileSet(domain; resolution = 10.0)
+    md=EarthSciData.loadmetadata(fs, "elevation")
+    nlon, nlat=md.varsize
+    lons_rad=md.coords[1]
+    lats_rad=md.coords[2]
 
     # --- Test dzdx: elevation ramp that only varies in longitude ---
-    target_slope_x = 0.15
-    elev_x = zeros(Float64, nlon, nlat)
+    target_slope_x=0.15
+    elev_x=zeros(Float64, nlon, nlat)
     for j in 1:nlat
         for i in 1:nlon
-            x_m = EarthSciData._LON2M * cos(lats_rad[j]) * (lons_rad[i] - lons_rad[1])
-            elev_x[i, j] = target_slope_x * x_m
+            x_m=EarthSciData._LON2M*cos(lats_rad[j])*(lons_rad[i]-lons_rad[1])
+            elev_x[i, j]=target_slope_x*x_m
         end
     end
-    dzdx = zeros(Float64, nlon, nlat)
+    dzdx=zeros(Float64, nlon, nlat)
     for j in 1:nlat
-        dx_per_rad = EarthSciData._LON2M * cos(lats_rad[j])
+        dx_per_rad=EarthSciData._LON2M*cos(lats_rad[j])
         for i in 1:nlon
-            if i == 1
-                dz = elev_x[2, j] - elev_x[1, j]
-                dlon = lons_rad[2] - lons_rad[1]
-            elseif i == nlon
-                dz = elev_x[nlon, j] - elev_x[nlon - 1, j]
-                dlon = lons_rad[nlon] - lons_rad[nlon - 1]
+            if i==1
+                dz=elev_x[2, j]-elev_x[1, j]
+                dlon=lons_rad[2]-lons_rad[1]
+            elseif i==nlon
+                dz=elev_x[nlon, j]-elev_x[nlon - 1, j]
+                dlon=lons_rad[nlon]-lons_rad[nlon - 1]
             else
-                dz = elev_x[i + 1, j] - elev_x[i - 1, j]
-                dlon = lons_rad[i + 1] - lons_rad[i - 1]
+                dz=elev_x[i + 1, j]-elev_x[i - 1, j]
+                dlon=lons_rad[i + 1]-lons_rad[i - 1]
             end
-            dzdx[i, j] = dz / (dlon * dx_per_rad)
+            dzdx[i, j]=dz/(dlon*dx_per_rad)
         end
     end
     # Interior points should recover the target slope.
-    @test all(abs.(dzdx[2:end-1, :] .- target_slope_x) .< 1e-6)
+    @test all(abs.(dzdx[2:(end - 1), :] .- target_slope_x) .< 1e-6)
 
     # --- Test dzdy: elevation ramp that only varies in latitude ---
-    target_slope_y = -0.08
-    elev_y = zeros(Float64, nlon, nlat)
+    target_slope_y=-0.08
+    elev_y=zeros(Float64, nlon, nlat)
     for j in 1:nlat
         for i in 1:nlon
-            y_m = EarthSciData._LAT2M * (lats_rad[j] - lats_rad[1])
-            elev_y[i, j] = target_slope_y * y_m
+            y_m=EarthSciData._LAT2M*(lats_rad[j]-lats_rad[1])
+            elev_y[i, j]=target_slope_y*y_m
         end
     end
-    dzdy = zeros(Float64, nlon, nlat)
+    dzdy=zeros(Float64, nlon, nlat)
     for j in 1:nlat
         for i in 1:nlon
-            if j == 1
-                dz = elev_y[i, 2] - elev_y[i, 1]
-                dlat = lats_rad[2] - lats_rad[1]
-            elseif j == nlat
-                dz = elev_y[i, nlat] - elev_y[i, nlat - 1]
-                dlat = lats_rad[nlat] - lats_rad[nlat - 1]
+            if j==1
+                dz=elev_y[i, 2]-elev_y[i, 1]
+                dlat=lats_rad[2]-lats_rad[1]
+            elseif j==nlat
+                dz=elev_y[i, nlat]-elev_y[i, nlat - 1]
+                dlat=lats_rad[nlat]-lats_rad[nlat - 1]
             else
-                dz = elev_y[i, j + 1] - elev_y[i, j - 1]
-                dlat = lats_rad[j + 1] - lats_rad[j - 1]
+                dz=elev_y[i, j + 1]-elev_y[i, j - 1]
+                dlat=lats_rad[j + 1]-lats_rad[j - 1]
             end
-            dzdy[i, j] = dz / (dlat * EarthSciData._LAT2M)
+            dzdy[i, j]=dz/(dlat*EarthSciData._LAT2M)
         end
     end
-    @test all(abs.(dzdy[:, 2:end-1] .- target_slope_y) .< 1e-6)
+    @test all(abs.(dzdy[:, 2:(end - 1)] .- target_slope_y) .< 1e-6)
 end
 
-@testitem "USGS3DEP System" setup = [USGS3DEPSetup] tags = [:usgs3dep] begin
+@testitem "USGS3DEP System" setup=[USGS3DEPSetup] tags=[:usgs3dep] begin
     using Symbolics
-    sys = USGS3DEP(domain; resolution=10.0)
+    sys=USGS3DEP(domain; resolution = 10.0)
     @test sys isa ModelingToolkit.AbstractSystem
     @test length(equations(sys)) == 3  # elevation + dzdx + dzdy
     # Check that all three variables exist
-    eq_names = [Symbolics.tosymbol(eq.lhs, escape=false) for eq in equations(sys)]
+    eq_names=[Symbolics.tosymbol(eq.lhs, escape = false) for eq in equations(sys)]
     @test :elevation ∈ eq_names
     @test :dzdx ∈ eq_names
     @test :dzdy ∈ eq_names
@@ -278,15 +279,15 @@ end
     lcc_domain = DomainInfo(
         DateTime(2018, 11, 8),
         DateTime(2018, 11, 9);
-        xrange=x_sw:dx:x_ne,
-        yrange=y_sw:dx:y_ne,
-        levrange=1:1,
-        spatial_ref=lcc_sr,
+        xrange = x_sw:dx:x_ne,
+        yrange = y_sw:dx:y_ne,
+        levrange = 1:1,
+        spatial_ref = lcc_sr
     )
 end
 
-@testitem "USGS3DEP LCC FileSet construction" setup = [USGS3DEPLCCSetup] tags = [:usgs3dep] begin
-    fs = EarthSciData.USGS3DEPFileSet(lcc_domain; resolution=10.0)
+@testitem "USGS3DEP LCC FileSet construction" setup=[USGS3DEPLCCSetup] tags=[:usgs3dep] begin
+    fs=EarthSciData.USGS3DEPFileSet(lcc_domain; resolution = 10.0)
     @test EarthSciData.varnames(fs) == ["elevation"]
     @test fs.width > 0
     @test fs.height > 0
@@ -297,55 +298,55 @@ end
     @test fs.bbox[4] >= 39.83
 end
 
-@testitem "USGS3DEP LCC data loading and interpolation" setup = [USGS3DEPLCCSetup] tags = [:usgs3dep] begin
-    fs = EarthSciData.USGS3DEPFileSet(lcc_domain; resolution=10.0)
-    ts, te = EarthSciMLBase.get_tspan_datetime(lcc_domain)
+@testitem "USGS3DEP LCC data loading and interpolation" setup=[USGS3DEPLCCSetup] tags=[:usgs3dep] begin
+    fs=EarthSciData.USGS3DEPFileSet(lcc_domain; resolution = 10.0)
+    ts, te=EarthSciMLBase.get_tspan_datetime(lcc_domain)
 
     # The DataSetInterpolator should handle the coord_trans from LCC→lonlat.
-    itp = EarthSciData.DataSetInterpolator{Float32}(
-        fs, "elevation", ts, te, lcc_domain; stream=true)
+    itp=EarthSciData.DataSetInterpolator{Float32}(
+        fs, "elevation", ts, te, lcc_domain; stream = true)
 
     # Interpolate at the LCC origin (0, 0) which corresponds to the projection centre.
-    val = EarthSciData.interp(itp, ts, Float32(0.0), Float32(0.0))
+    val=EarthSciData.interp(itp, ts, Float32(0.0), Float32(0.0))
     # Paradise, CA area elevation should be physically reasonable.
     @test 50 < val < 3000
 end
 
-@testitem "USGS3DEP LCC System construction" setup = [USGS3DEPLCCSetup] tags = [:usgs3dep] begin
+@testitem "USGS3DEP LCC System construction" setup=[USGS3DEPLCCSetup] tags=[:usgs3dep] begin
     using Symbolics
     # This should not error — previously it would fail because the data has
     # dimnames ["lon", "lat"] but an LCC domain has pvars [:x, :y].
-    sys = USGS3DEP(lcc_domain; resolution=10.0)
+    sys=USGS3DEP(lcc_domain; resolution = 10.0)
     @test sys isa ModelingToolkit.AbstractSystem
     @test length(equations(sys)) == 3  # elevation + dzdx + dzdy
-    eq_names = [Symbolics.tosymbol(eq.lhs, escape=false) for eq in equations(sys)]
+    eq_names=[Symbolics.tosymbol(eq.lhs, escape = false) for eq in equations(sys)]
     @test :elevation ∈ eq_names
     @test :dzdx ∈ eq_names
     @test :dzdy ∈ eq_names
 end
 
-@testitem "USGS3DEP LCC vs lonlat consistency" setup = [USGS3DEPLCCSetup, USGS3DEPSetup] tags = [:usgs3dep] begin
+@testitem "USGS3DEP LCC vs lonlat consistency" setup=[USGS3DEPLCCSetup, USGS3DEPSetup] tags=[:usgs3dep] begin
     # Both domains cover approximately the same region.
     # The elevation at the same physical location should match.
-    ts_ll, _ = EarthSciMLBase.get_tspan_datetime(domain)
-    ts_lcc, te_lcc = EarthSciMLBase.get_tspan_datetime(lcc_domain)
+    ts_ll, _=EarthSciMLBase.get_tspan_datetime(domain)
+    ts_lcc, te_lcc=EarthSciMLBase.get_tspan_datetime(lcc_domain)
 
     # Lon-lat interpolator
-    fs_ll = EarthSciData.USGS3DEPFileSet(domain; resolution=10.0)
-    itp_ll = EarthSciData.DataSetInterpolator{Float32}(
-        fs_ll, "elevation", ts_ll, ts_ll + Dates.Day(2), domain; stream=true)
+    fs_ll=EarthSciData.USGS3DEPFileSet(domain; resolution = 10.0)
+    itp_ll=EarthSciData.DataSetInterpolator{Float32}(
+        fs_ll, "elevation", ts_ll, ts_ll+Dates.Day(2), domain; stream = true)
 
     # LCC interpolator
-    fs_lcc = EarthSciData.USGS3DEPFileSet(lcc_domain; resolution=10.0)
-    itp_lcc = EarthSciData.DataSetInterpolator{Float32}(
-        fs_lcc, "elevation", ts_lcc, te_lcc, lcc_domain; stream=true)
+    fs_lcc=EarthSciData.USGS3DEPFileSet(lcc_domain; resolution = 10.0)
+    itp_lcc=EarthSciData.DataSetInterpolator{Float32}(
+        fs_lcc, "elevation", ts_lcc, te_lcc, lcc_domain; stream = true)
 
     # Query both at the projection centre (Paradise, CA).
-    lon_c = deg2rad(-121.60)
-    lat_c = deg2rad(39.78)
-    val_ll = EarthSciData.interp(itp_ll, ts_ll, Float32(lon_c), Float32(lat_c))
+    lon_c=deg2rad(-121.60)
+    lat_c=deg2rad(39.78)
+    val_ll=EarthSciData.interp(itp_ll, ts_ll, Float32(lon_c), Float32(lat_c))
 
-    val_lcc = EarthSciData.interp(itp_lcc, ts_lcc, Float32(0.0), Float32(0.0))
+    val_lcc=EarthSciData.interp(itp_lcc, ts_lcc, Float32(0.0), Float32(0.0))
 
     # Values should be close (not exact due to different grid resolutions).
     @test abs(val_ll - val_lcc) / max(abs(val_ll), abs(val_lcc)) < 0.1

--- a/test/usgs3dep_test.jl
+++ b/test/usgs3dep_test.jl
@@ -122,7 +122,7 @@ end
     # Interpolate at the centre of the domain
     lon_c=deg2rad(-121.60)
     lat_c=deg2rad(39.78)
-    val=EarthSciData.interp(itp, ts, Float32(lon_c), Float32(lat_c))
+    val=EarthSciData.interp!(itp, ts, Float32(lon_c), Float32(lat_c))
     @test 50 < val < 3000
 end
 
@@ -307,7 +307,7 @@ end
         fs, "elevation", ts, te, lcc_domain; stream = true)
 
     # Interpolate at the LCC origin (0, 0) which corresponds to the projection centre.
-    val=EarthSciData.interp(itp, ts, Float32(0.0), Float32(0.0))
+    val=EarthSciData.interp!(itp, ts, Float32(0.0), Float32(0.0))
     # Paradise, CA area elevation should be physically reasonable.
     @test 50 < val < 3000
 end
@@ -344,9 +344,9 @@ end
     # Query both at the projection centre (Paradise, CA).
     lon_c=deg2rad(-121.60)
     lat_c=deg2rad(39.78)
-    val_ll=EarthSciData.interp(itp_ll, ts_ll, Float32(lon_c), Float32(lat_c))
+    val_ll=EarthSciData.interp!(itp_ll, ts_ll, Float32(lon_c), Float32(lat_c))
 
-    val_lcc=EarthSciData.interp(itp_lcc, ts_lcc, Float32(0.0), Float32(0.0))
+    val_lcc=EarthSciData.interp!(itp_lcc, ts_lcc, Float32(0.0), Float32(0.0))
 
     # Values should be close (not exact due to different grid resolutions).
     @test abs(val_ll - val_lcc) / max(abs(val_ll), abs(val_lcc)) < 0.1

--- a/test/wrf_test.jl
+++ b/test/wrf_test.jl
@@ -87,9 +87,9 @@ end
         "WRF₊V(t, lon, lat, lev)",
         "MeanWind₊v_lev(t, lon, lat, lev)",
         "WRF₊W(t, lon, lat, lev)",
-        "WRF₊U_itp(WRF₊t_ref + t, lon, lat, lev)",
-        "WRF₊V_itp(WRF₊t_ref + t, lon, lat, lev)",
-        "WRF₊W_itp(WRF₊t_ref + t, lon, lat, lev)",
+        "interp_unsafe(WRF₊U_data",
+        "interp_unsafe(WRF₊V_data",
+        "interp_unsafe(WRF₊W_data",
         "WRF₊T(t, lon, lat, lev)",
         "WRF₊P(t, lon, lat, lev)",
         "WRF₊PB(t, lon, lat, lev)",
@@ -115,18 +115,30 @@ end
     end
 end
 
-@testitem "wrf total pressures" setup=[WRFSetup] begin
+# Helper: wrap the WRF system with a dummy state variable so that
+# ODEProblem + init work (DiffEq requires at least one DV).
+# The `init` call fires the SymbolicDiscreteCallback's `initialize`
+# affect, which loads data at tspan[1].
+@testsnippet WRFSolvedSetup begin
+    using ModelingToolkit: t, D
+    using OrdinaryDiffEqTsit5
     using SymbolicIndexingInterface: setp, getsym, parameter_values
 
-    wrf_sys = mtkcompile(WRF(domain))
-    prob = ODEProblem(wrf_sys, [], get_tref(domain))
-    f = getsym(prob, wrf_sys.P_total)
-    setter = setp(wrf_sys, [wrf_sys.lon, wrf_sys.lat, wrf_sys.lev])
-    ps = parameter_values(prob)
+    wrf_raw = WRF(domain)
+    @variables _dummy(t) = 0.0
+    _sys = compose(System([D(_dummy) ~ 0], t; name = :_w), wrf_raw)
+    wrf_compiled = mtkcompile(_sys)
+end
+
+@testitem "wrf total pressures" setup=[WRFSetup, WRFSolvedSetup] begin
+    prob = ODEProblem(wrf_compiled, [], get_tref(domain))
+    integ = init(prob, Tsit5())
+    f = getsym(integ, wrf_compiled.WRF.P_total)
+    setter = setp(integ, [wrf_compiled.WRF.lon, wrf_compiled.WRF.lat, wrf_compiled.WRF.lev])
 
     p_levels = map([1, 1.5, 2, 21.5, 30, 31.5]) do lev
-        setter(prob, [deg2rad(-118.2707), deg2rad(34.0059), lev])
-        f(prob)
+        setter(integ, [deg2rad(-118.2707), deg2rad(34.0059), lev])
+        f(integ)
     end
 
     p_want = [100331.86015842063, 100235.71904432855, 100139.57793023644,
@@ -135,6 +147,8 @@ end
 end
 
 @testitem "wrf lambert projection" setup=[WRFSetup] begin
+    using ModelingToolkit: t, D
+    using OrdinaryDiffEqTsit5
     using SymbolicIndexingInterface: setp, getsym, parameter_values
 
     domain = DomainInfo(
@@ -156,36 +170,36 @@ end
     )
     xv, yv = trans(lonv, latv)
 
-    wrf_sys = mtkcompile(WRF(domain))
-    prob = ODEProblem(wrf_sys, [], get_tref(domain))
-    f = getsym(prob, wrf_sys.P_total)
-    setter = setp(wrf_sys, [wrf_sys.x, wrf_sys.y, wrf_sys.lev])
-    ps = parameter_values(prob)
+    wrf_raw = WRF(domain)
+    @variables _dummy(t) = 0.0
+    _sys = compose(System([D(_dummy) ~ 0], t; name = :_w), wrf_raw)
+    compiled = mtkcompile(_sys)
+    prob = ODEProblem(compiled, [], get_tref(domain))
+    integ = init(prob, Tsit5())
+    f = getsym(integ, compiled.WRF.P_total)
+    setter = setp(integ, [compiled.WRF.x, compiled.WRF.y, compiled.WRF.lev])
 
     p_levels = map([1, 1.5, 2, 21.5, 30, 31.5]) do lev
-        setter(prob, [xv, yv, lev])
-        f(prob)
+        setter(integ, [xv, yv, lev])
+        f(integ)
     end
     p_want = [100099.2143558437, 100003.30283880791, 99907.39132177213, 67693.99609309093,
         30617.55578737014, 28672.612298322314]
     @test p_levels ≈ p_want
 end
 
-@testitem "wrf total pressures at fractional-hour timestamps (minutes/seconds)" setup=[WRFSetup] begin
-    using SymbolicIndexingInterface: setp, getsym, parameter_values
-
+@testitem "wrf total pressures at fractional-hour timestamps (minutes/seconds)" setup=[WRFSetup, WRFSolvedSetup] begin
     tstart = 25.0 * 60 + 36
     tend = tstart + 1
 
-    wrf_sys = mtkcompile(WRF(domain))
-    prob = ODEProblem(wrf_sys, [], (tstart, tend))
-    f = getsym(prob, wrf_sys.P_total)
-    setter = setp(wrf_sys, [wrf_sys.lon, wrf_sys.lat, wrf_sys.lev])
-    ps = parameter_values(prob)
+    prob = ODEProblem(wrf_compiled, [], (tstart, tend))
+    integ = init(prob, Tsit5())
+    f = getsym(integ, wrf_compiled.WRF.P_total)
+    setter = setp(integ, [wrf_compiled.WRF.lon, wrf_compiled.WRF.lat, wrf_compiled.WRF.lev])
 
     p_levels = map([1, 1.5, 2, 21.5, 30, 31.5]) do lev
-        setter(prob, [deg2rad(-118.2707), deg2rad(34.0059), lev])
-        f(prob)
+        setter(integ, [deg2rad(-118.2707), deg2rad(34.0059), lev])
+        f(integ)
     end
 
     p_want = [100295.9284090799, 100199.12630285477, 100102.32419662959, 67826.4962347177,
@@ -193,18 +207,15 @@ end
     @test p_levels ≈ p_want
 end
 
-@testitem "wrf δzδlev" setup=[WRFSetup] begin
-    using SymbolicIndexingInterface: setp, getsym, parameter_values
-
-    wrf_sys = mtkcompile(WRF(domain))
-    prob = ODEProblem(wrf_sys, [], get_tref(domain))
-    f = getsym(prob, wrf_sys.δzδlev)
-    setter = setp(wrf_sys, [wrf_sys.lon, wrf_sys.lat, wrf_sys.lev])
-    ps = parameter_values(prob)
+@testitem "wrf δzδlev" setup=[WRFSetup, WRFSolvedSetup] begin
+    prob = ODEProblem(wrf_compiled, [], get_tref(domain))
+    integ = init(prob, Tsit5())
+    f = getsym(integ, wrf_compiled.WRF.δzδlev)
+    setter = setp(integ, [wrf_compiled.WRF.lon, wrf_compiled.WRF.lat, wrf_compiled.WRF.lev])
 
     δzδlevs = map([1, 1.5, 2, 21.5, 30, 31.5]) do lev
-        setter(prob, [deg2rad(-118.2707), deg2rad(34.0059), lev])
-        f(prob)
+        setter(integ, [deg2rad(-118.2707), deg2rad(34.0059), lev])
+        f(integ)
     end
 
     δzδlev_want = [10.605308519529093, 16.96470420154144, 23.33493331829344,
@@ -212,18 +223,15 @@ end
     @test δzδlevs ≈ δzδlev_want
 end
 
-@testitem "wrf ground level vertical velocity" setup=[WRFSetup] begin
-    using SymbolicIndexingInterface: setp, getsym, parameter_values
-
-    wrf_sys = mtkcompile(WRF(domain))
-    prob = ODEProblem(wrf_sys, [], get_tref(domain))
-    f = getsym(prob, wrf_sys.W)
-    setter = setp(wrf_sys, [wrf_sys.lon, wrf_sys.lat, wrf_sys.lev])
-    ps = parameter_values(prob)
+@testitem "wrf ground level vertical velocity" setup=[WRFSetup, WRFSolvedSetup] begin
+    prob = ODEProblem(wrf_compiled, [], get_tref(domain))
+    integ = init(prob, Tsit5())
+    f = getsym(integ, wrf_compiled.WRF.W)
+    setter = setp(integ, [wrf_compiled.WRF.lon, wrf_compiled.WRF.lat, wrf_compiled.WRF.lev])
 
     ws = map([0.5, 1, 1.5, 2, 21.5, 30, 31.5]) do lev
-        setter(prob, [deg2rad(-118.2707), deg2rad(34.0059), lev])
-        f(prob)
+        setter(integ, [deg2rad(-118.2707), deg2rad(34.0059), lev])
+        f(integ)
     end
 
     w_want = [0.0, 0.00520469831395109, 0.01040939662790218, 0.011643543143849931,

--- a/test/wrf_test.jl
+++ b/test/wrf_test.jl
@@ -188,7 +188,8 @@ end
     @test p_levels ≈ p_want
 end
 
-@testitem "wrf total pressures at fractional-hour timestamps (minutes/seconds)" setup=[WRFSetup, WRFSolvedSetup] begin
+@testitem "wrf total pressures at fractional-hour timestamps (minutes/seconds)" setup=[
+    WRFSetup, WRFSolvedSetup] begin
     tstart = 25.0 * 60 + 36
     tend = tstart + 1
 


### PR DESCRIPTION
## Summary

- Replaces the `ITPWrapper`/`interp` approach with direct array-based `interp_unsafe` and a new `DataBufferType` wrapper for MTK's nonnumeric parameter buffer. This separates the data buffer (updated discretely via callbacks) from the symbolic interpolation, enabling future GPU compatibility.
- Introduces `DataBufferType` as a custom symtype that gives scalar shape (fixing `canonicalize_eq!` errors) while routing values to MTK's nonnumeric buffer (via `is_variable_floatingpoint` returning false).
- Fixes `needed_vars` to handle `Set` return type from newer MTK's `get_variables`.
- Registers zero derivatives for `interp_unsafe` to fix IMEX solver `*(::Type{Any}, ::Type{Real})` errors during `calculate_tgrad`.
- Propagates coordinate units to spatial grid constants, fixing WRF Lambert projection `ValidationError`.

## Key changes

- **`src/mtk_integration.jl`**: New `DataBufferType` struct, `@register_symbolic`/`@register_derivative` declarations, `promote_symtype`/`promote_shape` overrides, ifelse shape fix, simplified `_make_array_discrete`, updated `create_interp_equation` with spatial constant units, fixed `needed_vars`, updated `create_updater_sys_event`.
- **`src/load.jl`**: Array-based `interp_unsafe` implementations for 2D/3D/4D data with fractional index interpolation.
- **`src/geosfp.jl`, `src/wrf.jl`, `src/nei2016monthly.jl`, `src/NCEP-NCAR_Reanalysis.jl`**: Updated to use new `create_interp_equation` API returning `(eq, discretes, constants, interp_info)`, added `initial_conditions = _itp_defaults(all_params)` to System constructors.
- **`Project.toml`**: Cleaned up deps (removed OrdinaryDiffEqTsit5, TestItemRunner from `[deps]`).

## Test plan

- [ ] Verify `solve_test.jl` passes (single run, Strang Serial, Strang Threads, IMEX)
- [ ] Verify `wrf_test.jl` passes (total pressures, lambert projection)
- [ ] Verify `geosfp_test.jl` passes (pressure levels, structure tests)
- [ ] Verify `nei2016monthly_test.jl` passes
- [ ] Verify `NCEP-NCAR_Reanalysis_test.jl` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)