### PR TITLE
Fix knots2range NaN with single-point coordinate vectors

### DIFF
--- a/src/load.jl
+++ b/src/load.jl
@@ -332,32 +332,17 @@ mutable struct DataSetInterpolator{To, N, N2, FT, ITPT, DomT, ET, FSRG}
             )
         end
 
-        # Compute actual model grid sizes so the dummy interpolator type matches
-        # what will be created when real data is loaded (including singleton dims).
-        computed_grid = _compute_grid(domain, metadata.staggering)
-        if length(metadata.varsize) == 2 && metadata.zdim <= 0
-            model_coords = tuple_from_vals(metadata.xdim, computed_grid[1], metadata.ydim, computed_grid[2])
-        elseif length(metadata.varsize) >= 3
-            model_coords = tuple_from_vals(
-                metadata.xdim, computed_grid[1], metadata.ydim, computed_grid[2],
-                metadata.zdim, computed_grid[3])
-        else
-            error("Invalid data size")
-        end
-        spatial_sizes = length.(model_coords)
-
         load_cache = zeros(To, repeat([1], length(metadata.varsize))...)
-        data = zeros(To, spatial_sizes..., cache_size) # Add a dimension for time.
+        data = zeros(To, repeat([2], length(metadata.varsize))..., cache_size) # Add a dimension for time.
         interp_cache = similar(data)
         N = ndims(data)
         N2 = N - 1
         times = [DateTime(0, 1, 1) + Hour(i) for i in 1:cache_size]
-        dummy_coords = [range(0.0, step=0.1, length=s) for s in spatial_sizes]
         _,
         itp2 = create_interpolator!(
             interp_cache,
             data,
-            dummy_coords,
+            repeat([0:0.1:0.1], length(metadata.varsize)),
             times
         )
         ITPT = typeof(itp2)

--- a/src/load.jl
+++ b/src/load.jl
@@ -332,17 +332,32 @@ mutable struct DataSetInterpolator{To, N, N2, FT, ITPT, DomT, ET, FSRG}
             )
         end
 
+        # Compute actual model grid sizes so the dummy interpolator type matches
+        # what will be created when real data is loaded (including singleton dims).
+        computed_grid = _compute_grid(domain, metadata.staggering)
+        if length(metadata.varsize) == 2 && metadata.zdim <= 0
+            model_coords = tuple_from_vals(metadata.xdim, computed_grid[1], metadata.ydim, computed_grid[2])
+        elseif length(metadata.varsize) >= 3
+            model_coords = tuple_from_vals(
+                metadata.xdim, computed_grid[1], metadata.ydim, computed_grid[2],
+                metadata.zdim, computed_grid[3])
+        else
+            error("Invalid data size")
+        end
+        spatial_sizes = length.(model_coords)
+
         load_cache = zeros(To, repeat([1], length(metadata.varsize))...)
-        data = zeros(To, repeat([2], length(metadata.varsize))..., cache_size) # Add a dimension for time.
+        data = zeros(To, spatial_sizes..., cache_size) # Add a dimension for time.
         interp_cache = similar(data)
         N = ndims(data)
         N2 = N - 1
         times = [DateTime(0, 1, 1) + Hour(i) for i in 1:cache_size]
+        dummy_coords = [range(0.0, step=0.1, length=s) for s in spatial_sizes]
         _,
         itp2 = create_interpolator!(
             interp_cache,
             data,
-            repeat([0:0.1:0.1], length(metadata.varsize)),
+            dummy_coords,
             times
         )
         ITPT = typeof(itp2)
@@ -398,6 +413,9 @@ which is necessary to account for different numbers of days in each month
 and things like that.
 """
 function knots2range(knots, reltol = 0.05)
+    if length(knots) == 1
+        return knots[begin]:one(eltype(knots)):knots[begin]
+    end
     dx = diff(knots)
     dx_mean = sum(dx) / length(dx)
     #@assert all(abs.(1 .- dx ./ dx_mean) .<= reltol) "Knots ($knots) must be evenly spaced within reltol=$reltol."
@@ -407,14 +425,40 @@ function knots2range(knots, reltol = 0.05)
 end
 
 """
+Pad singleton dimensions in data and coords so that every axis has ≥ 2 elements,
+which is required by `BSpline(Linear())`.  Returns `(padded_data, padded_coords)`.
+"""
+function _pad_singletons(data, coords)
+    N = ndims(data)
+    needs_pad = ntuple(i -> size(data, i) == 1, N)
+    any(needs_pad) || return data, coords
+    pad_sizes = ntuple(i -> needs_pad[i] ? 2 : 1, N)
+    padded = repeat(data, pad_sizes...)
+    padded_coords = ntuple(N) do i
+        c = coords[i]
+        if needs_pad[i]
+            s = one(eltype(c))
+            first(c):s:(first(c) + s)
+        else
+            c
+        end
+    end
+    return padded, padded_coords
+end
+
+"""
 Create a new interpolator, overwriting `interp_cache`.
 """
 function create_interpolator!(interp_cache, data, coords, times)
     grid = tuple((knots2range(Float64.(c)) for c in coords)..., knots2range(datetime2unix.(times)))
-    copyto!(interp_cache, data)
+    padded, pad_grid = _pad_singletons(data, grid)
+    if size(interp_cache) != size(padded)
+        interp_cache = similar(padded)
+    end
+    copyto!(interp_cache, padded)
     itp = interpolate!(interp_cache, BSpline(Linear()))
-    itp = scale(itp, grid...)
-    return grid, itp
+    itp = scale(itp, pad_grid...)
+    return pad_grid, itp
 end
 
 function update_interpolator!(itp::DataSetInterpolator{To}) where {To}
@@ -424,7 +468,10 @@ function update_interpolator!(itp::DataSetInterpolator{To}) where {To}
     end
     coords = _model_grid(itp)
     grid, itp2 = create_interpolator!(tc.interp_cache, tc.data, coords, tc.times)
-    @assert all([length(g) for g in grid] .== size(tc.data)) "invalid data size: $([length(g) for g in grid]) != $(size(tc.data))"
+    # Grid may have been padded along singleton dimensions, so compare with
+    # the padded data size rather than tc.data.
+    padded_data, _ = _pad_singletons(tc.data, grid)
+    @assert all([length(g) for g in grid] .== size(padded_data)) "invalid data size: $([length(g) for g in grid]) != $(size(padded_data))"
     tc.itp = itp2
 end
 

--- a/src/regridding.jl
+++ b/src/regridding.jl
@@ -52,8 +52,9 @@ function interpolate_from!(dst::AbstractArray{T, N},
         src::AbstractArray{T, N}, mta::MetaData, model_grid, domain;
         extrapolate_type = Flat()) where {T, N}
     data_grid = Tuple(knots2range.(mta.coords))
-    itp = interpolate!(src, BSpline(Linear()))
-    itp = extrapolate(scale(itp, data_grid), extrapolate_type)
+    padded_src, padded_grid = _pad_singletons(src, data_grid)
+    itp = interpolate!(padded_src, BSpline(Linear()))
+    itp = extrapolate(scale(itp, padded_grid), extrapolate_type)
     ct = coord_trans(mta, domain)
     if N == 3
         for (i, x) in enumerate(model_grid[1])

--- a/test/load_test.jl
+++ b/test/load_test.jl
@@ -323,3 +323,101 @@ end
     @test EarthSciData.tuple_from_vals(2, 2, 1, 1, 3, 3) == (1, 2, 3)
     @test EarthSciData.tuple_from_vals(3, 3, 2, 2, 1, 1) == (1, 2, 3)
 end
+
+@testitem "knots2range singleton" begin
+    r = EarthSciData.knots2range([5.0])
+    @test length(r) == 1
+    @test first(r) == 5.0
+end
+
+@testitem "create_interpolator! with singleton dims" begin
+    using EarthSciData
+    using Interpolations: BSpline, Linear, interpolate!, scale
+    using Dates: DateTime, Hour, datetime2unix
+
+    # 2D spatial with one singleton dim + time
+    coords = (0.0:0.1:0.3, 0.0:1.0:0.0)  # dim 2 is singleton (length 1)
+    times = [DateTime(2024, 1, 1) + Hour(i) for i in 0:1]
+    data = ones(Float32, 4, 1, 2)
+    interp_cache = similar(data)
+
+    grid, itp = EarthSciData.create_interpolator!(interp_cache, data, coords, times)
+    @test length(grid) == 3
+    @test length(grid[2]) == 2  # singleton padded to 2
+
+    # Query should work — value should be 1.0 everywhere
+    @test itp(0.1, 0.5, datetime2unix(times[1])) ≈ 1.0f0
+end
+
+@testitem "DummyFileSet singleton dim" begin
+    using EarthSciMLBase: DomainInfo
+    using Dates: datetime2unix, DateTime, Second, Hour
+    using Interpolations: scale, interpolate, BSpline, Linear
+
+    domain = DomainInfo(
+        DateTime(2022, 5, 1),
+        DateTime(2022, 5, 3);
+        lonrange = deg2rad(-175.0):deg2rad(2.5):deg2rad(175.0),
+        latrange = deg2rad(-85.0):deg2rad(2):deg2rad(85.0),
+        levrange = 1:1  # singleton level dimension
+    )
+
+    struct SingletonDimFS <: EarthSciData.FileSet
+        start::DateTime
+        finish::DateTime
+    end
+
+    function EarthSciData.DataFrequencyInfo(
+            fs::SingletonDimFS,
+    )::EarthSciData.DataFrequencyInfo
+        frequency = Second(3 * 3600)
+        centerpoints = collect((fs.start + frequency / 2):frequency:(fs.finish))
+        EarthSciData.DataFrequencyInfo(fs.start, frequency, centerpoints)
+    end
+
+    tv(fs, t) = (t - fs.start) / (fs.finish - fs.start)
+
+    function EarthSciData.loadslice!(
+            cache::AbstractArray,
+            fs::SingletonDimFS,
+            t::DateTime,
+            varname
+    )
+        dfi = EarthSciData.DataFrequencyInfo(fs)
+        tt = dfi.centerpoints[EarthSciData.centerpoint_index(dfi, t)]
+        v = tv(fs, tt)
+        cache[:, :, 1] .= v  # Fill all lon/lat with same value, singleton lev
+    end
+
+    function EarthSciData.loadmetadata(fs::SingletonDimFS, varname)
+        return EarthSciData.MetaData(
+            [[0.0, 0.5, 1.0], [0.0, 1.0], [850.0]],  # 3 coords: lon, lat, lev (singleton)
+            "m",
+            "description",
+            ["lon", "lat", "lev"],
+            [3, 2, 1],  # varsize with singleton lev
+            "+proj=longlat +datum=WGS84 +no_defs",
+            1,  # xdim
+            2,  # ydim
+            3,  # zdim
+            (false, false, false)  # staggering
+        )
+    end
+
+    fs = SingletonDimFS(DateTime(2022, 4, 30), DateTime(2022, 5, 4))
+
+    # Should not throw an error during construction
+    itp = EarthSciData.DataSetInterpolator{Float32}(
+        fs,
+        "U",
+        DateTime(2022, 5, 1),
+        DateTime(2022, 5, 3),
+        domain;
+        stream = true
+    )
+
+    # Should be able to interpolate without error
+    val = EarthSciData.interp(itp, DateTime(2022, 5, 1, 1), deg2rad(0.25f0), deg2rad(0.5f0), 1.0f0)
+    @test !isnan(val)
+    @test isfinite(val)
+end


### PR DESCRIPTION
## Summary

- Fix `knots2range` division by zero when given a single-element coordinate vector (e.g., `levrange = 1:1` with ERA5 data)
- Add `_pad_singletons` helper that extends singleton dimensions to size 2 by repeating data, which is required by `BSpline(Linear())`
- Apply padding in both `create_interpolator!` (temporal interpolation) and `interpolate_from!` (spatial regridding)
- Fix `DataSetInterpolator` constructor to compute actual model grid sizes instead of hardcoded size-2 dummy data, ensuring the interpolator type parameter (`ITPT`) matches real data shape

Fixes #192

## Test plan

- [x] Added `knots2range singleton` test verifying single-element input returns length-1 range
- [x] Added `create_interpolator! with singleton dims` test verifying interpolation works with padded singleton dimensions
- [x] Added `DummyFileSet singleton dim` end-to-end test with 3D data where the vertical dimension has size 1
- [ ] CI: verify existing tests pass (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)