### PR TITLE
Reduce USGS 3DEP pixel cap to 1000x1000 and add download timeout

### DIFF
--- a/docs/src/usgs3dep.md
+++ b/docs/src/usgs3dep.md
@@ -65,7 +65,7 @@ eqs = equations(elev)
 
 1. **Bounding box**: The spatial extent of the domain is converted to a WGS84 (EPSG:4326) longitude/latitude bounding box with a one-pixel buffer.
 
-2. **Download**: A single GeoTIFF tile covering the bounding box is requested from the USGS ImageServer `exportImage` endpoint. Pixel dimensions are computed from the requested resolution, capped at 4000x4000 to limit download size. The tile is cached locally.
+2. **Download**: A single GeoTIFF tile covering the bounding box is requested from the USGS ImageServer `exportImage` endpoint. Pixel dimensions are computed from the requested resolution, capped at 1000x1000 to limit download size. The tile is cached locally.
 
 3. **Coordinate mapping**: Pixel-centre coordinates are computed analytically from the bounding box and pixel dimensions (no GeoTIFF metadata parsing needed). Coordinates are stored in radians for consistency with the EarthSciML coordinate system.
 

--- a/src/load.jl
+++ b/src/load.jl
@@ -127,10 +127,11 @@ end
 """
 Download a file with a progress bar, deleting the partial file on error.
 """
-function _download_with_progress(download_url::AbstractString, path::AbstractString)
+function _download_with_progress(download_url::AbstractString, path::AbstractString; timeout::Real=300)
     try
         prog = Progress(100; desc = "Downloading $(basename(download_url)):", dt = 0.1)
         Downloads.download(download_url, path,
+            timeout = timeout,
             progress = (
                 total::Integer, now::Integer) -> begin
                 prog.n = total

--- a/src/usgs3dep.jl
+++ b/src/usgs3dep.jl
@@ -39,7 +39,8 @@ Create a USGS3DEPFileSet covering the spatial extent of the given domain.
 # Arguments
 - `domaininfo`: A `DomainInfo` or `GridSpec` providing the spatial domain.
 - `resolution`: Target resolution in arc-seconds (default 1/3 ≈ 10m).
-  The pixel count is capped at 4000×4000 to avoid excessive download sizes.
+  The pixel count is capped at 1000×1000 to avoid excessive download sizes
+  and API timeouts.
 """
 function USGS3DEPFileSet(domaininfo; resolution=1 / 3)
     grid = _compute_grid(domaininfo, (false, false, false))
@@ -95,8 +96,8 @@ function USGS3DEPFileSet(domaininfo; resolution=1 / 3)
     # Compute pixel dimensions from the requested resolution.
     width = ceil(Int, (bbox[3] - bbox[1]) * 3600 / resolution)
     height = ceil(Int, (bbox[4] - bbox[2]) * 3600 / resolution)
-    width = clamp(width, 1, 4000)
-    height = clamp(height, 1, 4000)
+    width = clamp(width, 1, 1000)
+    height = clamp(height, 1, 1000)
 
     # Static dataset: use two centerpoints bracketing the domain time range
     # so that any query time within the domain is interpolable.

--- a/test/usgs3dep_test.jl
+++ b/test/usgs3dep_test.jl
@@ -64,10 +64,10 @@ end
     @test rad2deg(first(md.coords[2])) > fs.bbox[2]
     @test rad2deg(last(md.coords[2])) < fs.bbox[4]
 
-    # Pixel clamping: very fine resolution should hit the 4000-pixel cap
+    # Pixel clamping: very fine resolution should hit the 1000-pixel cap
     fs_fine = EarthSciData.USGS3DEPFileSet(domain; resolution=0.001)
-    @test fs_fine.width == 4000
-    @test fs_fine.height == 4000
+    @test fs_fine.width == 1000
+    @test fs_fine.height == 1000
 
     # Invalid varname should error
     @test_throws AssertionError EarthSciData.loadmetadata(fs, "temperature")


### PR DESCRIPTION
## Summary

- Reduce the USGS 3DEP pixel dimension cap from 4000×4000 to 1000×1000 to avoid API rejections and timeouts on large requests (~40m resolution is still sufficient for most applications)
- Add a 300-second timeout to `_download_with_progress` (previously relied on system default ~20s, which was too short for large tiles)
- Update tests and documentation to reflect the new cap

Fixes #193

## Test plan

- [ ] Offline structural tests pass (pixel clamping test updated to expect 1000)
- [ ] Network-dependent tests pass with smaller tile sizes
- [ ] Other data sources (LANDFIRE, etc.) unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)