### PR TITLE
Cut allocations and dynamic dispatch on the interpolation hot path

### DIFF
--- a/src/load.jl
+++ b/src/load.jl
@@ -232,6 +232,32 @@ struct DataFrequencyInfo
     frequency::Union{Dates.Period, Dates.CompoundPeriod}
     "Time representing the temporal center of each record."
     centerpoints::Vector{DateTime}
+    "Precomputed bucket boundaries for `centerpoint_index`: the i-th element
+    is the midpoint between `centerpoints[i-1]` and `centerpoints[i]`, with
+    `middles[1] = centerpoints[1]` so the first bucket begins there."
+    middles::Vector{DateTime}
+    function DataFrequencyInfo(start::DateTime,
+            frequency::Union{Dates.Period, Dates.CompoundPeriod},
+            centerpoints)
+        # Accept any iterable of DateTime (e.g. `StepRange{DateTime, Day}` from
+        # the daily-file loaders) to preserve the previous auto-generated
+        # constructor's behaviour, and materialize into `Vector{DateTime}` so
+        # the precomputed `middles` stay in sync with `centerpoints`.
+        cp::Vector{DateTime} = centerpoints isa Vector{DateTime} ? centerpoints :
+                               collect(DateTime, centerpoints)
+        new(start, frequency, cp, _compute_middles(cp))
+    end
+end
+
+function _compute_middles(cpts::Vector{DateTime})
+    n = length(cpts)
+    m = Vector{DateTime}(undef, n)
+    n == 0 && return m
+    m[1] = cpts[1]
+    @inbounds for i in 2:n
+        m[i] = cpts[i - 1] + (cpts[i] - cpts[i - 1]) / 2
+    end
+    return m
 end
 
 """
@@ -253,9 +279,7 @@ function centerpoint_index(t_info::DataFrequencyInfo, t::DateTime)
         ),
         )
     end
-    diffs = diff(cpts)
-    middles = (cpts[1], (cpts[i] + diffs[i] / 2 for i in 1:(length(cpts) - 1))...)
-    findlast((x) -> x <= t, middles)
+    return searchsortedlast(t_info.middles, t)
 end
 
 """
@@ -541,34 +565,59 @@ function update!(itp::DataSetInterpolator, t::DateTime)
     tc = itp.cache
     @assert tc.initialized "Interpolator has not been initialized"
     times = interp_cache_times!(itp, t) # Figure out which times we need.
-
-    # Figure out the overlap between the times we have and the times we need.
-    times_in_cache = intersect(times, tc.times)
-    idxs_in_cache = [findfirst(x -> x == times_in_cache[i], tc.times)
-                     for i in eachindex(times_in_cache)]
-    idxs_in_times = [findfirst(x -> x == times_in_cache[i], times)
-                     for i in eachindex(times_in_cache)]
-    idxs_not_in_times = setdiff(eachindex(times), idxs_in_times)
-
-    # Move data we already have to where it should be.
     N = ndims(tc.data_buffer)
-    if all(idxs_in_cache .> idxs_in_times) && all(issorted.((idxs_in_cache, idxs_in_times)))
-        for (new, old) in zip(idxs_in_times, idxs_in_cache)
-            selectdim(tc.data_buffer, N, new) .= selectdim(tc.data_buffer, N, old)
+    n_new = length(times)
+    n_old = length(tc.times)
+
+    # Find the overlap between the times we already have (`tc.times`) and
+    # the times we need (`times`). Both vectors are sorted contiguous windows
+    # over the same centerpoint list, so a single merge walk in O(n + m)
+    # finds every matching pair with no allocations. For any overlap, the
+    # index offset `delta = old - new` is constant; we use it to drive one
+    # in-place shift instead of allocating intersect/findfirst/setdiff
+    # vectors as the previous implementation did.
+    first_new = 0
+    delta = 0
+    overlap_count = 0
+    j = 1
+    @inbounds for i in 1:n_new
+        while j <= n_old && tc.times[j] < times[i]
+            j += 1
         end
-    elseif all(idxs_in_cache .< idxs_in_times) &&
-           all(issorted.((idxs_in_cache, idxs_in_times)))
-        for (new, old) in zip(reverse(idxs_in_times), reverse(idxs_in_cache))
-            selectdim(tc.data_buffer, N, new) .= selectdim(tc.data_buffer, N, old)
+        if j <= n_old && tc.times[j] == times[i]
+            if overlap_count == 0
+                first_new = i
+                delta = j - i
+            elseif j - i != delta
+                error("Unexpected time ordering in cache update")
+            end
+            overlap_count += 1
+            j += 1
         end
-    elseif !all(idxs_in_cache .== idxs_in_times)
-        error(
-            "Unexpected time ordering, can't reorder indexes $(idxs_in_times) to $(idxs_in_cache)",
-        )
     end
 
-    # Load the additional times we need
-    for idx in idxs_not_in_times
+    # Move overlapping data in place when the overlap has shifted.
+    if overlap_count > 0 && delta != 0
+        if delta > 0
+            # Source indices are higher than destinations — walk forward.
+            @inbounds for i in first_new:(first_new + overlap_count - 1)
+                selectdim(tc.data_buffer, N, i) .= selectdim(tc.data_buffer, N, i + delta)
+            end
+        else
+            # Source indices are lower than destinations — walk backward.
+            @inbounds for i in (first_new + overlap_count - 1):-1:first_new
+                selectdim(tc.data_buffer, N, i) .= selectdim(tc.data_buffer, N, i + delta)
+            end
+        end
+    end
+
+    # Load times not covered by the overlap.
+    lo = first_new
+    hi = first_new + overlap_count - 1
+    @inbounds for idx in 1:n_new
+        if overlap_count > 0 && lo <= idx <= hi
+            continue
+        end
         d = selectdim(tc.data_buffer, N, idx)
         if fetch(tc.loadtask) != times[idx] # Check if correct time is already loaded.
             load_data_for_time!(itp, times[idx]) # Load data if not already loaded.

--- a/src/mtk_integration.jl
+++ b/src/mtk_integration.jl
@@ -503,11 +503,15 @@ function build_interp_event(interp_infos, starttime::DateTime)
     # path, so the cost is negligible.
     n_interps = length(interp_infos)
     data_bufs = Vector{Any}(undef, n_interps)
+    # Hoisted: `result_vals` and the NamedTuple key-tuple are reused across
+    # every callback fire instead of being rebuilt each time. The callback is
+    # serialized by `update_lock`, so in-place mutation is safe.
+    result_vals = Vector{Any}(undef, 3 * n_interps)
+    mod_keys_tuple = Tuple(mod_keys)
     update_lock = ReentrantLock()
 
     function update_data!(modified, observed, ctx, integ)
         lock(update_lock) do
-            result_vals = Vector{Any}(undef, 3 * n_interps)
             i = 0
             for (_, dsi) in pairs(ctx)
                 i += 1
@@ -544,7 +548,7 @@ function build_interp_event(interp_infos, starttime::DateTime)
                 result_vals[3i - 1] = ts
                 result_vals[3i] = tstep
             end
-            NamedTuple{Tuple(mod_keys)}(Tuple(result_vals))
+            NamedTuple{mod_keys_tuple}(Tuple(result_vals))
         end
     end
 

--- a/src/regridding.jl
+++ b/src/regridding.jl
@@ -86,6 +86,38 @@ function interpolate_from!(dst::AbstractArray{T, N},
 end
 
 """
+Callable regridder for staggered grids that interpolates a source field onto
+the model grid. Typed fields keep the per-timestep call site statically
+dispatched; the earlier closure-based implementation could capture its
+variables with abstract types.
+"""
+struct InterpolatingRegridder{MT, MG, DT}
+    metadata::MT
+    model_grid::MG
+    domain::DT
+end
+
+function (r::InterpolatingRegridder)(dst::AbstractArray, src::AbstractArray;
+        extrapolate_type = Flat())
+    interpolate_from!(dst, src, r.metadata, r.model_grid, r.domain;
+        extrapolate_type = extrapolate_type)
+end
+
+"""
+Callable regridder for non-staggered grids that uses `ConservativeRegridding`.
+`extrapolate_type` is accepted for a uniform call signature but is unused here.
+"""
+struct ConservativeRegridderCallable{RG, MT}
+    regridder::RG
+    metadata::MT
+end
+
+function (r::ConservativeRegridderCallable)(dst::AbstractArray, src::AbstractArray;
+        extrapolate_type = Flat())
+    regrid_horizontal!(dst, r.regridder, src, r.metadata)
+end
+
+"""
 Create a regridding function for the given file set, metadata, and domain.
 If any dimensions are staggered, use interpolation; otherwise, use conservative regridding.
 `extrapolate_type` specifies the extrapolation method for interpolation; it is only used
@@ -94,19 +126,9 @@ when interpolation is selected.
 function regridder(fs::FileSet, metadata::MetaData, domain::DomainInfo)
     if any(metadata.staggering) # Are any of the dimensions staggered?
         model_grid = EarthSciMLBase.grid(domain, metadata.staggering)
-        regrid! = (dst::AbstractArray,
-            src::AbstractArray;
-            extrapolate_type = Flat()) -> begin
-            interpolate_from!(dst, src, metadata, model_grid, domain;
-                extrapolate_type = extrapolate_type)
-        end
+        return InterpolatingRegridder(metadata, model_grid, domain)
     else
-        regridder = horizontal_regridder(fs, metadata, domain)
-        regrid! = (dst::AbstractArray,
-            src::AbstractArray;
-            extrapolate_type = Flat()) -> begin
-            regrid_horizontal!(dst, regridder, src, metadata)
-        end
+        rg = horizontal_regridder(fs, metadata, domain)
+        return ConservativeRegridderCallable(rg, metadata)
     end
-    return regrid!
 end


### PR DESCRIPTION
## Summary

Addresses four hot-path allocation / dynamic-dispatch issues found in a
performance audit of the interpolation machinery:

- **`build_interp_event` callback** (`src/mtk_integration.jl`): the per-fire
  `Vector{Any}` `result_vals` and the `Tuple(mod_keys)` conversion are now
  hoisted out of the closure and reused across fires. The callback is
  already serialized by `update_lock`, so in-place mutation is safe.
- **`update!` cache refresh** (`src/load.jl`): the intersect / findfirst /
  setdiff-based overlap detection is replaced with a single O(n + m)
  merge walk over the two sorted time vectors. This eliminates four
  allocations and two O(n²) `findfirst` scans on every cache refresh.
  For contiguous windows over the same centerpoint list (always true
  via `interp_cache_times!`), any overlap sits at a constant index
  offset, which drives a single in-place shift.
- **`DataFrequencyInfo`** (`src/load.jl`): the bucket midpoints are now
  precomputed once at construction, and `centerpoint_index` uses
  `searchsortedlast` instead of allocating `diff` + a generator-splatted
  tuple and doing a linear `findlast`. The constructor accepts any
  iterable of `DateTime` (e.g. `StepRange{DateTime, Day}`) so existing
  callers continue to work.
- **Regridder factory** (`src/regridding.jl`): the two anonymous closures
  returned by `regridder(fs, metadata, domain)` are replaced with typed
  callable structs (`InterpolatingRegridder`, `ConservativeRegridderCallable`).
  The call site stored in `FileSetWithRegridder` now dispatches through
  concrete, explicitly-typed fields.

No behavior changes are intended — the merge walk preserves the original
`update!` semantics (same forward/backward shift patterns, same error on
inconsistent ordering), the precomputed midpoints produce the same
bucket boundaries as the generator-based version, and the callable
structs forward to the same `interpolate_from!` / `regrid_horizontal!`
implementations.

## Test plan

- [ ] `Pkg.test()` on the full suite passes (in progress — running
      locally, will update once complete)
- [x] `DataFrequencyInfo(::DateTime, ::Day, ::StepRange)` still
      constructs (preserves the auto-generated constructor's coercion)
- [x] `centerpoint_index` returns the same indices for known inputs
- [x] Merge-walk overlap detection verified on forward-shift /
      backward-shift / identical / disjoint cases
- [ ] `bench/runbenchmarks.jl` — pending

Not tackled in this PR (flagged by the audit but larger-scope / riskier):
parameterizing the `::Any` fields on `GEOSFPFileSet` / `WRFFileSet` /
`CEDSFileSet` / `NEI2016MonthlyEmisFileSet` / `NetCDFOutputter`. Those
would require thinking through mutable-struct field reassignment and the
`NCDataset` `UnionAll` parameters separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)