### PR TITLE
Fix NEI2016MonthlyEmis over-emission: normalize monthly totals by days-in-month

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "EarthSciData"
 uuid = "a293c155-435f-439d-9c11-a083b6b47337"
-version = "0.16.4"
+version = "0.16.5"
 authors = ["EarthSciML Authors"]
 
 [deps]

--- a/src/nei2016monthly.jl
+++ b/src/nei2016monthly.jl
@@ -241,13 +241,24 @@ function loadslice!(
         data = reshape(data, size(data)..., 1)
         var = loadslice!(data, fs, fs.ds, t, varname, "TSTEP")
 
-        # Step 1: Apply unit conversion from the file (typically tons/day to kg/s)
+        # Step 1: Normalize the stored monthly totals to a per-day rate.
+        # Despite the `units = "tons/day"` attribute, the EPA gridded-merge
+        # monthly files store effectively *monthly* totals on a single 24-hour
+        # TSTEP, so the labeled `tons/day` value is really a whole month's
+        # worth of emissions.  Dividing by the number of days in the month
+        # converts it to a true daily rate before the unit conversion below
+        # treats it as `tons/day`.  Without this, the constant-rate value is
+        # applied on every model day and over-emits by ~daysinmonth (~30×).
+        # See https://github.com/EarthSciML/EarthSciData.jl/issues/209.
+        data ./= Dates.daysinmonth(t)
+
+        # Step 2: Apply unit conversion from the file (typically tons/day to kg/s)
         scale, _ = to_unit(var.attrib["units"])
         if scale != 1
             data .*= scale  # Now data is in kg/s per grid cell
         end
 
-        # Step 2: Convert from kg/s per grid cell to kg/s/m² for conservative regridding
+        # Step 3: Convert from kg/s per grid cell to kg/s/m² for conservative regridding
         # This is the flux density that can be conservatively regridded
         Δx = fs.ds.attrib["XCELL"]  # Cell width in meters
         Δy = fs.ds.attrib["YCELL"]  # Cell height in meters

--- a/test/nei2016monthly_test.jl
+++ b/test/nei2016monthly_test.jl
@@ -145,6 +145,45 @@ import Proj
         @test sol.u[end][end] != 0.0  # Ensure we get a nonzero result
     end
 
+    @testset "daysinmonth normalization" begin
+        # Regression test for https://github.com/EarthSciML/EarthSciData.jl/issues/209.
+        # The EPA gridded-merge monthly files carry a `units = "tons/day"`
+        # attribute but actually store monthly totals on a single 24-hour
+        # TSTEP.  `loadslice!` must divide by `daysinmonth(t)` so the value is
+        # a true daily rate before the tons/day→kg/s conversion; otherwise the
+        # injected emissions are ~daysinmonth (~30×) too high.
+        (; fileset) = setup()
+        varname = "NO"
+        meta = EarthSciData.loadmetadata(fileset, varname)
+        sample_time = DateTime(2016, 5, 15)
+
+        # Value the public loader actually feeds to the regridder.
+        loaded = zeros(Float64, meta.varsize...)
+        EarthSciData.loadslice!(loaded, fileset, sample_time, varname)
+
+        # Independently reconstruct the expected kg/s/m² value: pull the raw
+        # monthly slice for the same TSTEP (via the inner loader, which selects
+        # the time index exactly as the public one does), then apply the unit
+        # conversion, cell-area division, and the days-in-month normalization.
+        expected = zeros(Float64, meta.varsize...)
+        EarthSciData.lock(EarthSciData.nclock) do
+            tmp = reshape(expected, size(expected)..., 1)
+            var = EarthSciData.loadslice!(
+                tmp, fileset, fileset.ds, sample_time, varname, "TSTEP")
+            scale, _ = EarthSciData.to_unit(var.attrib["units"])
+            Δx = fileset.ds.attrib["XCELL"]
+            Δy = fileset.ds.attrib["YCELL"]
+            expected .*= scale
+            expected ./= (Δx * Δy)
+            expected ./= Dates.daysinmonth(sample_time)
+        end
+
+        @test Dates.daysinmonth(sample_time) == 31
+        @test loaded ≈ expected
+        # Sanity check: the normalization made a real difference (not a no-op).
+        @test !(loaded ≈ expected .* Dates.daysinmonth(sample_time))
+    end
+
     @testset "diurnal_itp function" begin
         # Test domain starts at 2016-05-01 00:00:00 UTC
         t_ref_numeric = datetime2unix(DateTime(2016, 5, 1))  # Domain starts at 2016-05-01 00:00:00

--- a/test/solve_test.jl
+++ b/test/solve_test.jl
@@ -47,7 +47,7 @@ end
         # the ODEProblem solve result below).
         prob = ODEProblem(sys2, [], get_tspan(domain))
         sol = solve(prob, Tsit5())
-        @test only(sol.u[end]) ≈ 3.017283738615849e-6 rtol = 0.01
+        @test only(sol.u[end]) ≈ 9.916966804519471e-8 rtol = 0.01
     end
 
     @testset "Strang Serial" begin
@@ -56,7 +56,7 @@ end
         st = SolverStrangSerial(Tsit5(), dt)
         prob = ODEProblem(csys, st)
         sol = solve(prob, Euler(), dt = dt)
-        @test sum(sol.u[end]) ≈ 2.014381322963178e-5 rtol = 0.01
+        @test sum(sol.u[end]) ≈ 6.62176884520524e-7 rtol = 0.01
     end
 
     @testset "Strang Threads" begin
@@ -65,7 +65,7 @@ end
         st = SolverStrangThreads(Tsit5(), dt)
         prob = ODEProblem(csys, st)
         sol = solve(prob, Euler(), dt = dt)
-        @test sum(sol.u[end]) ≈ 2.014381322963178e-5 rtol = 0.01
+        @test sum(sol.u[end]) ≈ 6.621768845915271e-7 rtol = 0.01
     end
 
     @testset "IMEX" begin
@@ -74,6 +74,6 @@ end
         st = SolverIMEX()
         prob = ODEProblem(csys, st)
         sol = solve(prob, KenCarp3())
-        @test sum(sol.u[end]) ≈ 1.824462850685205e-5 rtol = 0.15
+        @test sum(sol.u[end]) ≈ 5.990519547082663e-7 rtol = 0.15
     end
 end


### PR DESCRIPTION
## Summary

Fixes #209.

`NEI2016MonthlyEmis` was injecting ~`Dates.daysinmonth(t)` (~30×) too much emission for every species.

The EPA `2016fh_16j_mrggrid_*_12US1_month_*.ncf` files carry a `units = "tons/day"` attribute but actually store **monthly totals** on a single 24-hour `TSTEP`. The previous `loadslice!` applied only the file-unit conversion (`tons/day → kg/s`) and a cell-area division — no per-month normalization — so a whole month's emissions were applied as a constant rate on *every* model day.

As documented in the issue, this produces physically impossible totals (e.g. 1530 Tg/yr of CO from CONUS alone, larger than total global CO emissions), and the over-emission factor is a uniform ~30.5× (= mean days-in-month) across all species independent of their seasonal cycle — the signature of a missing days-in-month normalization.

## Change

In `src/nei2016monthly.jl`, divide the loaded slice by `Dates.daysinmonth(t)` to convert the stored monthly total into a true daily rate before the existing `tons/day → kg/s` conversion:

```julia
data ./= Dates.daysinmonth(t)
```

## Testing

- Added a regression test (`test/nei2016monthly_test.jl`, "daysinmonth normalization") that independently reconstructs the expected `kg/s/m²` value from the raw monthly slice including the `÷ daysinmonth` factor and asserts the public loader matches it (and that the normalization is not a no-op). Verified passing locally.
- Bumped version to 0.16.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)