### PR TITLE
Renormalize CO day-of-week factors to conserve the weekly total

### DIFF
--- a/src/nei2016monthly.jl
+++ b/src/nei2016monthly.jl
@@ -131,11 +131,11 @@ delp_dry_surface_itp(lon::DynamicQuantities.Quantity, lat::DynamicQuantities.Qua
 # the wrapper-equation builder in `NEI2016MonthlyEmis` to keep the
 # species-dispatch in one table instead of an `if/elseif` chain.
 const _NEI_SCALING_FN = Dict{String, Function}(
-    "CO"   => nei_scale_CO,
+    "CO" => nei_scale_CO,
     "FORM" => diurnal_itp,
     "ISOP" => diurnal_itp_ISOP,
-    "NO"   => nei_scale_NOx,
-    "NO2"  => nei_scale_NOx,
+    "NO" => nei_scale_NOx,
+    "NO2" => nei_scale_NOx
 )
 
 """
@@ -367,10 +367,9 @@ function varnames(fs::NEI2016MonthlyEmisFileSet)
     end
 end
 
-Base.close(fs::NEI2016MonthlyEmisFileSet) =
-    lock(nclock) do ;
-        close(fs.ds);
-    end
+Base.close(fs::NEI2016MonthlyEmisFileSet) = lock(nclock) do ;
+    close(fs.ds);
+end
 
 # Verify that `varname`'s grid metadata matches `ref_meta` on every dimension
 # the shared regridder depends on.  Throws if any of {native_sr, xdim, ydim,

--- a/src/nei2016monthly.jl
+++ b/src/nei2016monthly.jl
@@ -13,7 +13,12 @@ const DIURNAL_FACTORS_ISOP = [
     2.6616, 2.6184, 2.4408, 2.1288, 1.6896, 1.1448, 0.5136, 0, 0, 0, 0]
 
 const DayofWeekFactors_NOx = [1.0706, 1.0706, 1.0706, 1.0706, 1.0706, 0.863, 0.784]
-const DayofWeekFactors_CO = [1.076, 1.1076, 1.0706, 1.0706, 1.0706, 0.779, 0.683]
+# Renormalized to weekly mean 1.0 so the day-of-week redistribution conserves the
+# monthly CO total (the NOx array above and the diurnal profiles are already
+# mean-1.0). The raw NEI99 CO factors summed to 6.857 (mean 0.9796), which
+# under-emitted CO by ~2%.
+const DayofWeekFactors_CO_raw = [1.076, 1.1076, 1.0706, 1.0706, 1.0706, 0.779, 0.683]
+const DayofWeekFactors_CO = DayofWeekFactors_CO_raw .* (7 / sum(DayofWeekFactors_CO_raw))
 
 # Load and create interpolator for delp_dry_surface
 const DELP_DRY_SURFACE_ITP = let

--- a/test/nei2016monthly_test.jl
+++ b/test/nei2016monthly_test.jl
@@ -193,11 +193,13 @@ import Proj
 
         # 6 AM UTC
         six_am_utc = t_ref_numeric + 6 * 3600.0  # 7th factor
-        @test EarthSciData.diurnal_itp(six_am_utc, lon_utc) == EarthSciData.DIURNAL_FACTORS[7]
+        @test EarthSciData.diurnal_itp(six_am_utc, lon_utc) ==
+              EarthSciData.DIURNAL_FACTORS[7]
 
         # 6 PM UTC
         six_pm_utc = t_ref_numeric + 18 * 3600.0  # 19th factor
-        @test EarthSciData.diurnal_itp(six_pm_utc, lon_utc) == EarthSciData.DIURNAL_FACTORS[19]
+        @test EarthSciData.diurnal_itp(six_pm_utc, lon_utc) ==
+              EarthSciData.DIURNAL_FACTORS[19]
 
         # Test 2: Chicago (UTC-6, longitude ~ -87.6°)
         lon_chicago = deg2rad(-87.6)  # Chicago longitude
@@ -385,7 +387,9 @@ import Proj
         for (i, lon_val) in enumerate(lon_grid)
             for (j, lat_val) in enumerate(lat_grid)
                 eq = D(NO) ~ emis.NO / uc
-                sys = compose(System([eq], t, [NO], [uc]; name = Symbol("NO_sys_$(i)_$(j)")), emis)
+                sys = compose(
+                    System(
+                        [eq], t, [NO], [uc]; name = Symbol("NO_sys_$(i)_$(j)")), emis)
                 sys = mtkcompile(sys)
                 # After composition, parameters are namespaced; extract them from the compiled system
                 ps = parameters(sys)
@@ -460,7 +464,6 @@ import Proj
         @test ACET_map[1, 1, end] != 0.0  # Ensure we get nonzero emissions
     end
 end
-
 
 @testset "CO day-of-week factors conserve the weekly total" begin
     # Regression for the renormalization: the raw NEI99 CO factors summed to

--- a/test/nei2016monthly_test.jl
+++ b/test/nei2016monthly_test.jl
@@ -460,3 +460,17 @@ import Proj
         @test ACET_map[1, 1, end] != 0.0  # Ensure we get nonzero emissions
     end
 end
+
+
+@testset "CO day-of-week factors conserve the weekly total" begin
+    # Regression for the renormalization: the raw NEI99 CO factors summed to
+    # 6.857 (mean 0.9796), silently under-emitting CO by ~2%. The applied
+    # factors must sum to exactly 7 (weekly mass conservation) while keeping
+    # the raw day-to-day proportions.
+    f = EarthSciData.DayofWeekFactors_CO
+    raw = EarthSciData.DayofWeekFactors_CO_raw
+    @test sum(f) ≈ 7.0 rtol = 1e-12
+    @test all(f ./ raw .≈ 7 / sum(raw))
+    t_mon = Dates.datetime2unix(Dates.DateTime(2016, 3, 7, 12))  # a Monday
+    @test EarthSciData.dayofweek_itp_CO(t_mon, 0.0) == f[1]
+end


### PR DESCRIPTION

**bugfix · behavior-changing numerics (weekly CO ≈ +2%; no API change)**

## Motivation
The raw NEI99 CO day-of-week factors sum to 6.8574 (mean 0.9796), so applying them as-is under-emits CO by ~2% relative to the monthly total the factors are meant to redistribute.

## Change
Scale the applied factors by `7 / sum(raw)` (×1.0208) so they sum to exactly 7 (weekly mass conservation) while preserving the raw day-to-day proportions. The raw array is kept alongside as `DayofWeekFactors_CO_raw` with a comment recording the rationale.

## Why this departs from the current design
This changes numeric constants the package has shipped, so weekly CO emissions rise ~2%. The justification is the factors' own design intent: a day-of-week profile *redistributes* a fixed monthly inventory total across weekdays, so its mean must be 1 — a mean ≠ 1 profile silently rescales the total the inventory defines. Every other temporal profile in `nei2016monthly.jl` already satisfies this: `DayofWeekFactors_NOx` sums to exactly 7.0000, and all three 24-hour diurnal profiles sum to 24 (mean 1.0; ISOP within 0.01%). The CO array is the lone outlier at 6.8574. Renormalizing by `7/sum(raw)` is the minimal fix: it restores conservation while leaving the NEI99 day-to-day signal (the weekday/weekend contrast) exactly proportional to the raw data. Leaving the raw values in place would keep conflating an activity-timing profile with an undocumented −2% net CO bias.

An alternative reading of the raw array is that the Mon/Tue entries (`1.0760`/`1.1076`) are transcriptions of the `1.0706` used for Wed–Fri, which would also explain the deficit; the renormalization is agnostic to that — it restores weekly conservation either way while preserving the shipped day-to-day proportions, and the raw array is kept alongside for reference.

![CO day-of-week factors before/after renormalization; raw sum 6.8574 → 7 exactly](https://cdn.jsdelivr.net/gh/xk-y/EarthSciData-prfork.jl@pr-assets/co_dow_renormalization.png)

**Figure** — Mon–Sun factors before/after, read from the committed code. Raw sum = 6.8574 (weekly CO under-emitted −2.04%; the renormalization *raises* CO ≈ +2%); renormalized sum = 7 exactly.

## Validation
New testset (`nei2016monthly_test.jl`): `sum(DayofWeekFactors_CO) ≈ 7` (rtol 1e-12), every applied/raw ratio equals `7/sum(raw)` (proportions preserved), and `dayofweek_itp_CO` indexes the applied table correctly for a known Monday. Per-PR CI: the conservation testset passed; the branch's only failures are the upstream/main baseline's pre-existing network-only WRF failures (data-host TLS certificate expired), no code failures. (The baseline's third network-only failure, `ceds_test` — an ORNL 362 MB download timeout — was excluded from the local run via upstream's own `EARTHSCIDATA_TEST_FILES` mechanism; GitHub CI runs it normally.)

## Notes
Release note: CO surface emissions rise ~2% vs the previous behavior.

---

*Part of the coordinated cross-repo update tracked in EarthSciML/GasChem.jl#225.*

