### PR TITLE
Callback-aware interpolator prune (2-arg factory)

### DIFF
--- a/src/mtk_integration.jl
+++ b/src/mtk_integration.jl
@@ -407,14 +407,15 @@ function interp_callable(sys, varname::Symbol; parent_scope::Bool = false)
         get_name(sym) = ModelingToolkit.getname(
             sym isa Symbolics.Num ? Symbolics.unwrap(sym) : sym)
         via(sym) = PS(getproperty(sys, get_name(sym)))
-        info = merge(info, (
-            data_sym = via(info.data_sym),
-            tstart_sym = via(info.tstart_sym),
-            tstep_sym = via(info.tstep_sym),
-            spatial_consts = Any[via(c) for c in info.spatial_consts],
-            extrap_const = via(info.extrap_const),
-            unit_const = via(info.unit_const),
-        ))
+        info = merge(info,
+            (
+                data_sym = via(info.data_sym),
+                tstart_sym = via(info.tstart_sym),
+                tstep_sym = via(info.tstep_sym),
+                spatial_consts = Any[via(c) for c in info.spatial_consts],
+                extrap_const = via(info.extrap_const),
+                unit_const = via(info.unit_const)
+            ))
     end
     return InterpCallable(info)
 end
@@ -562,7 +563,7 @@ function build_interp_event(interp_infos, starttime::DateTime)
         keys = (
             EarthSciMLBase.var2symbol(info.data_sym),
             EarthSciMLBase.var2symbol(info.tstart_sym),
-            EarthSciMLBase.var2symbol(info.tstep_sym),
+            EarthSciMLBase.var2symbol(info.tstep_sym)
         )
         push!(per_interp_keys, keys)
         append!(mod_keys, keys)
@@ -895,7 +896,7 @@ function _apply_live_mask!(interp_infos, parent_sys; extra_needed = ())
         push!(referenced, string(EarthSciMLBase.var2symbol(v)))
     end
     is_needed = [any(s -> matches(bare_data_syms[k], s), referenced) ||
-                 any(s -> matches(bare_var_syms[k], s), referenced)
+                     any(s -> matches(bare_var_syms[k], s), referenced)
                  for k in eachindex(interp_infos)]
     if any(is_needed)
         kept = String[]

--- a/src/mtk_integration.jl
+++ b/src/mtk_integration.jl
@@ -971,21 +971,28 @@ $(SIGNATURES)
 Build a `SysDiscreteEvent`-shaped factory closing over `interp_infos`.
 EarthSciMLBase's `convert(::Type{System}, ::CoupledSystem)` walks every
 subsystem's `SysDiscreteEvent` metadata and calls each factory with the
-temp coupled+`mtkcompile`d parent system; this factory side-effects the
-captured `interp_info.live` Refs, eagerly allocates and NetCDF-loads the
-full-grid buffer for every surviving interp (so the data is present in
-`info.preloaded_buf[]` before any `ODEProblem` is built), and returns
-`nothing`, so the discrete event list passed to the parent is empty.
-EarthSciMLBase's walker filters `nothing` returns, so registering this
-factory adds no new discrete events to the parent system — the existing
-loader-attached `build_interp_event` callback fires as before, just with
-a settled live mask and pre-populated buffers by the time it runs.
+temp coupled+`mtkcompile`d parent system.  The returned closure accepts
+two calling conventions:
 
-`operator_vars` is *not* consulted here because the factory only sees the
-post-compile `System` (no `CoupledSystem` access).  Workflows using
-`EarthSciMLBase.Operator`s should bypass auto-pruning by calling
-[`prune_unused_interps!`](@ref) on the `CoupledSystem` directly (which
-does include `operator_vars`).
+  - Legacy 1-arg `f(parent_sys)`: performs *no* pruning.  With only the
+    compiled parent `System` there is no way to know which met fields
+    the coupled system's operators and init-callbacks consume
+    out-of-band, so pruning here would starve them (e.g. drop a
+    callback-only `A1₊PBLH`); every interpolator stays live and its
+    data loads lazily on first use.
+  - 2-arg `f(parent_sys, extra_needed)`: an EarthSciMLBase whose
+    `convert` forwards the operator- and callback-advertised variables
+    calls this form; the factory applies the live mask
+    (`_apply_live_mask!`), pruning interpolators referenced neither by
+    the compiled system's equations nor by `extra_needed`.
+
+Both forms return `nothing`, and EarthSciMLBase's walker filters
+`nothing` returns, so registering this factory adds no new discrete
+events to the parent system — the existing loader-attached
+`build_interp_event` callback fires as before, just with a settled live
+mask in the 2-arg case.  [`prune_unused_interps!`](@ref) on the
+`CoupledSystem` remains the explicit operator- and callback-aware prune
+path for callers who want it.
 """
 function make_prune_factory(interp_infos)
     # Backward-compatible with two `convert(System, ::CoupledSystem)` walker

--- a/src/mtk_integration.jl
+++ b/src/mtk_integration.jl
@@ -936,11 +936,31 @@ variables via `EarthSciMLBase.operator_vars`, and call
 post-`mtkcompile` parent system so callers can use it for
 `ODEProblem(parent_sys, ...)`.
 """
+# Collect the interpolated met vars needed by BOTH the coupled system's operators
+# (`operator_vars`, over `csys.ops`) AND its init-callbacks (each one's
+# `get_needed_vars`, e.g. `PBLMixingCallback` needs `A1₊PBLH`). Callback needs are
+# consumed out-of-band (in callback observed functions) and so are invisible to the
+# equation-reference scan in `_apply_live_mask!`; collecting them here keeps the
+# prune from dropping callback-only met fields. Mirrors `EarthSciMLBase.operator_vars`,
+# extended to `csys.init_callbacks`.
+function _operator_and_callback_vars(csys, parent_sys)
+    isnothing(csys.domaininfo) && return ()
+    ov = isempty(csys.ops) ? Any[] :
+         collect(EarthSciMLBase.operator_vars(csys, parent_sys, csys.domaininfo))
+    cv = Any[]
+    for c in csys.init_callbacks
+        sig = Tuple{typeof(c), typeof(csys), typeof(parent_sys), typeof(csys.domaininfo)}
+        if hasmethod(EarthSciMLBase.get_needed_vars, sig)
+            append!(cv, EarthSciMLBase.get_needed_vars(c, csys, parent_sys, csys.domaininfo))
+        end
+    end
+    return unique(vcat(ov, cv))
+end
+
 function prune_unused_interps!(
         loader_sys, csys::EarthSciMLBase.CoupledSystem; kwargs...)
     parent_sys = convert(ModelingToolkit.System, csys; kwargs...)
-    extra = isnothing(csys.domaininfo) || isempty(csys.ops) ? () :
-            EarthSciMLBase.operator_vars(csys, parent_sys, csys.domaininfo)
+    extra = _operator_and_callback_vars(csys, parent_sys)
     prune_unused_interps!(loader_sys, parent_sys; extra_needed = extra)
     return parent_sys
 end
@@ -968,8 +988,30 @@ post-compile `System` (no `CoupledSystem` access).  Workflows using
 does include `operator_vars`).
 """
 function make_prune_factory(interp_infos)
-    return function (parent_sys)
-        _apply_live_mask!(interp_infos, parent_sys)
+    # Backward-compatible with two `convert(System, ::CoupledSystem)` walker
+    # conventions:
+    #
+    #   • legacy `f(parent_sys)` (1 arg): the walker gives us only the compiled
+    #     parent System, so we cannot know which met vars the coupled system's
+    #     operators/callbacks need. Pruning on equation-references alone is UNSAFE —
+    #     met fields consumed only out-of-band by callbacks (e.g. GEOSFP `A1₊PBLH`,
+    #     read solely by `EnvironmentalTransport.PBLMixingCallback`'s observed fn)
+    #     appear in no compiled equation and would be pruned to `live[] = false`,
+    #     leaving a zero-sentinel buffer → `pblh ≈ 0 → imix = 1` → `pbl_full_mix!`
+    #     early-returns → zero PBL vertical mixing → surface tracers trapped in
+    #     level 1 → O3 titration collapse. So we SKIP pruning here; every interp
+    #     stays live and loads lazily via `_update_one_interp!` / `_preload_interp!`.
+    #
+    #   • `f(parent_sys, extra_needed)` (2 args): an EarthSciMLBase that passes the
+    #     operator + init-callback needed vars (see `operator_vars` and each
+    #     init-callback's `get_needed_vars`). With those we CAN prune safely, keeping
+    #     the callback-consumed met fields live.
+    #
+    # Either way `prune_unused_interps!(loader, csys)` remains the explicit,
+    # operator- and callback-aware prune path for callers who want it.
+    return function (parent_sys, extra_needed = nothing)
+        extra_needed === nothing && return nothing  # legacy 1-arg caller: cannot prune safely
+        _apply_live_mask!(interp_infos, parent_sys; extra_needed = extra_needed)
         return nothing
     end
 end

--- a/test/interp_pruning_test.jl
+++ b/test/interp_pruning_test.jl
@@ -144,3 +144,36 @@ using Test
     end
     @test length(initialized) == 1
 end
+
+
+using EarthSciData: make_prune_factory
+using ModelingToolkit: t_nounits, D_nounits
+
+using ModelingToolkit
+using ModelingToolkit: t_nounits as t, D_nounits as D
+
+# tiny real System: the 2-arg prune path inspects observed(parent_sys)
+@variables x(t)
+@named _mini = System([D(x) ~ 0], t)
+const _msys = mtkcompile(_mini)
+
+@testset "Data: prune factory 1-arg/2-arg contract" begin
+    # Empty interp_infos keeps the test independent of any dataset: the point is
+    # the DISPATCH branch, and _apply_live_mask! over [] is a well-defined no-op.
+    f = make_prune_factory(Any[])
+    @test f isa Function
+
+    # 1-arg (legacy walker): must return nothing AND not attempt to prune.
+    # A safe skip keeps callback-only met vars live — a callback-only met var
+    # (A1₊PBLH) sits in no compiled equation, so equation-only pruning would drop
+    # it. The legacy path therefore keeps every interp live.
+    @test f(nothing) === nothing
+
+    # 2-arg with an explicit keep-set: takes the prune path (no error on []).
+    @test f(_msys, String[]) === nothing
+    @test f(_msys, ["GEOSFP₊A1₊PBLH"]) === nothing
+
+    # the two branches are selected exactly as the convert() call site does it
+    @test applicable(f, _msys, String[])            # 2-arg method exists
+    @test applicable(f, nothing)                       # 1-arg (default extra_needed) too
+end

--- a/test/interp_pruning_test.jl
+++ b/test/interp_pruning_test.jl
@@ -177,3 +177,144 @@ const _msys = mtkcompile(_mini)
     @test applicable(f, _msys, String[])            # 2-arg method exists
     @test applicable(f, nothing)                       # 1-arg (default extra_needed) too
 end
+
+# Regression test for the callback-aware prune (PR #217): `_apply_live_mask!`
+# must keep an interpolator alive when it appears in `extra_needed` — the
+# operator/init-callback keep-set that `_operator_and_callback_vars` forwards
+# through the 2-arg prune path — even though no compiled equation references
+# it.  Unlike the dispatch-contract testset above, this one runs the
+# live-masking logic on REAL `interp_info` entries (built by
+# `create_interp_equation` via the same offline synthetic-ERA5 fixture as the
+# first testset), so the mask actually executes on non-empty input.
+@testset "Regression: _apply_live_mask! keeps callback-needed interps live" begin
+    # Explicit bindings: the `t_nounits as t` import above is ignored by Julia
+    # (conflicting import warning), so grab the unitful iv/derivative directly.
+    tu = ModelingToolkit.t
+    Du = ModelingToolkit.D
+
+    era5_dir = mktempdir()
+
+    lon_vals = Float64.(-130.0:2.0:-60.0)
+    lat_vals = Float64.(20.0:2.0:50.0)
+    plev_vals = Float64.([1000, 975, 950, 925])
+    hours_per_day = 0:6:18
+
+    # Three variables, one per pruning role:
+    #   t — referenced by the parent system's only state equation (equation-needed);
+    #   q — referenced by NO equation: stands in for a callback-only met var
+    #       (the GEOSFP `A1₊PBLH` role — consumed out-of-band by
+    #       `PBLMixingCallback`'s observed function, so invisible to the
+    #       equation-reference scan);
+    #   u — needed by nothing (must actually be pruned, proving the mask ran).
+    era5_vars = Dict(
+        "t" => ("K", "Temperature", 260.0, 300.0),
+        "q" => ("kg kg**-1", "Specific humidity", 0.0, 0.02),
+        "u" => ("m s**-1", "U component of wind", -15.0, 15.0)
+    )
+
+    nlon, nlat, nplev = length(lon_vals), length(lat_vals), length(plev_vals)
+    fpath = joinpath(era5_dir, "era5_pl_2022_01.nc")
+    time_vals = DateTime[]
+    for d in 1:Dates.daysinmonth(2022, 1), h in hours_per_day
+        push!(time_vals, DateTime(2022, 1, d, h))
+    end
+    ntime = length(time_vals)
+
+    NCDataset(fpath, "c") do ds
+        defDim(ds, "longitude", nlon)
+        defDim(ds, "latitude", nlat)
+        defDim(ds, "pressure_level", nplev)
+        defDim(ds, "valid_time", ntime)
+        defVar(ds, "longitude", Float64, ("longitude",))[:] = lon_vals
+        defVar(ds, "latitude", Float64, ("latitude",))[:] = lat_vals
+        defVar(ds, "pressure_level", Float64, ("pressure_level",))[:] = plev_vals
+        nctime = defVar(ds, "valid_time", Float64, ("valid_time",),
+            attrib = Dict("units" => "hours since 1900-01-01 00:00:00",
+                "calendar" => "proleptic_gregorian"))
+        nctime[:] = time_vals
+        for (varname, (unit_str, long_name, vmin, vmax)) in era5_vars
+            ncvar = defVar(ds, varname, Float32,
+                ("longitude", "latitude", "pressure_level", "valid_time"),
+                attrib = Dict("units" => unit_str, "long_name" => long_name))
+            data = Array{Float32}(undef, nlon, nlat, nplev, ntime)
+            for ti in 1:ntime, k in 1:nplev, j in 1:nlat, i in 1:nlon
+                frac = (i + j + k + ti) / (nlon + nlat + nplev + ntime)
+                data[i, j, k, ti] = Float32(vmin + (vmax - vmin) * frac)
+            end
+            ncvar[:, :, :, :] = data
+        end
+    end
+
+    domain_reg = DomainInfo(
+        DateTime(2022, 1, 1), DateTime(2022, 1, 2);
+        latrange = deg2rad(20.0f0):deg2rad(2.0):deg2rad(50.0f0),
+        lonrange = deg2rad(-130.0f0):deg2rad(2.0):deg2rad(-60.0f0),
+        levrange = 1:4
+    )
+    era5 = ERA5(domain_reg; mirror = "file://$(era5_dir)",
+        variables = ["t", "q", "u"])
+
+    infos = ModelingToolkit.getmetadata(era5, EarthSciData.InterpInfos, nothing)
+    @test length(infos) == 3
+    info_for(n) = infos[findfirst(i -> i.var_sym == Symbol("pl₊", n), infos)]
+    t_info, q_info, u_info = info_for("t"), info_for("q"), info_for("u")
+    reset_live!() = foreach(i -> i.live[] = true, infos)
+    @test all(i.live[] for i in infos)
+
+    # Parent state equation references only the temperature interpolator.
+    @variables Creg(tu)=0.0 [unit = u"K*s"]
+    eq = Du(Creg) ~ era5.pl₊t
+    parent = mtkcompile(compose(
+        System([eq], tu, [Creg], []; name = :reg_state), era5))
+
+    # The callback-needed variable exactly as the real caller supplies it:
+    # `_operator_and_callback_vars` forwards symbolic variables of the compiled
+    # parent system (e.g. from `get_needed_vars(::PBLMixingCallback, ...)`), so
+    # pull `ERA5₊pl₊q` back out of the compiled system's observed equations.
+    qvar = only(filter(
+        v -> endswith(string(EarthSciMLBase.var2symbol(v)), "₊pl₊q"),
+        [obs_eq.lhs for obs_eq in ModelingToolkit.observed(parent)]))
+
+    # (a) Equation-only prune (no keep-set): the hazard PR #217 guards against.
+    # The callback-only variable is indistinguishable from an unused one and is
+    # dropped alongside it.
+    mask = EarthSciData._apply_live_mask!(infos, parent)
+    @test t_info.live[]
+    @test !q_info.live[]   # callback-only var wrongly dropped without keep-set
+    @test !u_info.live[]
+    @test mask == [i.live[] for i in infos]
+
+    # (b) THE regression: the same prune through the factory's 2-arg path with
+    # the keep-set the real caller forwards.  The callback-needed interpolator
+    # must survive, and the genuinely unused one must still be pruned (i.e. the
+    # mask actually executed rather than no-op'ing).
+    reset_live!()
+    f = make_prune_factory(infos)
+    @test f(parent, [qvar]) === nothing
+    @test t_info.live[]    # equation-needed: kept
+    @test q_info.live[]    # callback-needed: kept via extra_needed — the fix
+    @test !u_info.live[]   # unused: pruned
+
+    # (c) 2-arg with an EMPTY keep-set reproduces (a) through the factory:
+    # pruning still runs, so the callback-only variable is dropped again.
+    reset_live!()
+    @test f(parent, Any[]) === nothing
+    @test t_info.live[]
+    @test !q_info.live[]
+    @test !u_info.live[]
+
+    # (d) Legacy 1-arg factory call: no keep-set can exist, so no pruning at
+    # all — every interpolator stays live (the backward-compatible safe skip).
+    reset_live!()
+    @test f(parent) === nothing
+    @test all(i.live[] for i in infos)
+
+    # (e) Shipped safety fallback: pruning against a parent that references NO
+    # interpolator (with an empty keep-set) keeps everything live rather than
+    # dropping everything.
+    reset_live!()
+    @variables xreg(tu)
+    mini = mtkcompile(System([Du(xreg) ~ 0], tu; name = :reg_mini))
+    EarthSciData._apply_live_mask!(infos, mini)
+    @test all(i.live[] for i in infos)
+end

--- a/test/interp_pruning_test.jl
+++ b/test/interp_pruning_test.jl
@@ -44,6 +44,7 @@ using Test
     fpath = joinpath(era5_dir, "era5_pl_2022_01.nc")
     time_vals = DateTime[]
     for d in 1:Dates.daysinmonth(2022, 1), h in hours_per_day
+
         push!(time_vals, DateTime(2022, 1, d, h))
     end
     ntime = length(time_vals)
@@ -98,7 +99,7 @@ using Test
 
     # Parent state references only the temperature interpolator (`pl₊t`).
     # All other ERA5 variables (u, v, w, q, ...) are unreferenced.
-    @variables C(t)=0.0 [unit = u"K*s"]
+    @variables C(t) = 0.0 [unit = u"K*s"]
     eq = D(C) ~ era5.pl₊t
     sys_unsimp = compose(System([eq], t, [C], []; name = :state), era5)
     sys = mtkcompile(sys_unsimp)
@@ -139,12 +140,11 @@ using Test
     # `needed_vars(integ.f.sys)` so subsequent fires (and the init fire
     # itself) skip `lazyload!` on dead interpolators.
     for v in ["u", "v", "w", "q", "r", "z", "d", "vo", "o3", "cc",
-              "ciwc", "clwc", "crwc", "cswc", "pv"]
+        "ciwc", "clwc", "crwc", "cswc", "pv"]
         @test v in not_initialized
     end
     @test length(initialized) == 1
 end
-
 
 using EarthSciData: make_prune_factory
 using ModelingToolkit: t_nounits, D_nounits
@@ -216,6 +216,7 @@ end
     fpath = joinpath(era5_dir, "era5_pl_2022_01.nc")
     time_vals = DateTime[]
     for d in 1:Dates.daysinmonth(2022, 1), h in hours_per_day
+
         push!(time_vals, DateTime(2022, 1, d, h))
     end
     ntime = length(time_vals)
@@ -262,7 +263,7 @@ end
     @test all(i.live[] for i in infos)
 
     # Parent state equation references only the temperature interpolator.
-    @variables Creg(tu)=0.0 [unit = u"K*s"]
+    @variables Creg(tu) = 0.0 [unit = u"K*s"]
     eq = Du(Creg) ~ era5.pl₊t
     parent = mtkcompile(compose(
         System([eq], tu, [Creg], []; name = :reg_state), era5))


### PR DESCRIPTION

**default-behavior change · companion to EarthSciMLBase callback_vars PR**

## Motivation
The auto live-mask prune drops interpolators that appear in no compiled equation. Met fields consumed only out-of-band by init-callbacks — notably GEOSFP `A1₊PBLH`, read solely by `PBLMixingCallback`'s observed function — are exactly those, so equation-only pruning set `live[]=false`, left a zero-sentinel buffer, and produced `pblh≈0 → imix=1 →` no PBL vertical mixing → surface tracers trapped in level 1 → **O3 titration collapse**. The mechanism is self-contained: a field read only by an init-callback's observed function is pruned to a zero buffer and silently returns zeros — nothing errors. As an illustrative downstream symptom (author-side, not in-repo evidence), in a 30-lev CONUS SuperFast run this caused a full-run failure rather than a perturbation: emitted NOx accumulated to 400–530 ppb in the lowest layer and titrated surface O3 to collapse, while levels 2–30 stayed frozen at their initial condition.

## Change
`make_prune_factory` returns a closure with two call conventions:
- **1-arg** (legacy walker): cannot know operator/callback-needed vars → **skips pruning** (safe default; every interp stays live and lazy-loads).
- **2-arg** `(parent_sys, extra_needed)`: an EarthSciMLBase that passes the operator + init-callback keep-set (see the companion EarthSciMLBase `callback_vars` + 2-arg factory forwarding PR) → prunes safely, keeping callback-consumed fields live.

The explicit `prune_unused_interps!(loader, csys)` path is extended the same way: its keep-set now collects `operator_vars` **and** each init-callback's `get_needed_vars` (new `_operator_and_callback_vars` helper), so an explicit prune of a coupled system with a `PBLMixingCallback`-style consumer keeps that field live instead of starving it.

## Why this departs from the current design
Upstream makes equation-reference pruning the default. This PR inverts that default only on the path that structurally cannot prune correctly:

- **Pruning is only correct with the full consumer set.** Compiled equations are one consumer class; operator and init-callback observed functions are another, invisible to the equation-reference scan. The legacy 1-arg factory receives only the compiled `parent_sys`, so it can never see the callback consumers.
- **The failure modes are asymmetric.** Over-pruning is silent scientific corruption: the dropped field keeps returning its zero-sentinel buffer — no error, no NaN, just wrong physics for the whole run (the PBLH incident above). Not pruning merely lazy-loads fields that turn out unused — a visible, bounded performance cost, recoverable at any time via the explicit `prune_unused_interps!(loader, csys)` call or the 2-arg path.
- **The pruning benefit is not lost on the standard path.** With the companion EarthSciMLBase `callback_vars` + 2-arg factory forwarding PR merged, `convert(System, ::CoupledSystem)` supplies the operator + init-callback keep-set to the 2-arg method, so coupled workflows still prune — now safely.
- **The first-affect auto-prune fallback is deliberately unchanged.** It only fires on integrators that expose `integ.f.sys` (plain direct solves, incl. `compose + mtkcompile`); the operator-split solvers — the only paths where operators/init-callbacks actually run — build inner integrators with `integ.f.sys === nothing` and rely on the convert-time factory walk, which is exactly the path this PR makes callback-aware. Where the fallback fires, no out-of-band callback consumers exist, so equation-reference pruning stays valid there.

## Validation
Two testsets in `interp_pruning_test.jl`:
- **Contract test** (6 assertions): 1-arg call returns `nothing` (no prune); 2-arg call takes the mask path (with empty and non-empty keep-sets); both dispatch branches are `applicable`.
- **Regression test on real interpolators** (offline synthetic-ERA5 fixture, three vars in the three pruning roles): an equation-needed var is kept; a **callback-only var survives exactly when it is in the 2-arg keep-set** (passed as the same symbolic-variable type the real `_operator_and_callback_vars` caller forwards) and is dropped without it; a genuinely unused var is always pruned (proving the mask executed, not no-op'd); the legacy 1-arg call keeps everything live; and the no-interpolator-parent fallback keeps everything live.

The forwarding side is integration-tested through `convert(System, ::CoupledSystem)` in the EarthSciMLBase companion PR. Per-PR CI: contract test passed; the branch's only failures are the upstream/main baseline's pre-existing network-only WRF failures (the baseline's third network-only failure, `ceds_test`, was excluded from the local run via upstream's own `EARTHSCIDATA_TEST_FILES` mechanism; GitHub CI runs it normally). Author-side integration evidence (not reproducible from this repo): in the author's downstream 48 h CONUS CTM, the fixed configuration (prune skipped / callback keep-set supplied) restores PBL mixing.

## Dependencies
Merge **after** EarthSciMLBase "callback_vars + 2-arg factory forwarding" so the 2-arg keep-set is actually supplied. Standalone, the 1-arg safe-skip means no intermediate broken state.

## Notes
Default-behavior change (was: prune on equation references; now: legacy path does not prune). The explicit operator/callback-aware path remains `prune_unused_interps!(loader, csys)`.


## Figure

![Callback-aware prune: auto-prune drops a callback's interpolator -> PBL mixing silent -> NOx trapped -> surface O3 titrated; callback-aware prune keeps it live](https://cdn.jsdelivr.net/gh/xk-y/EarthSciData-prfork.jl@pr-assets/callback_prune_mechanism.png)

Illustrative mechanism (no run value is asserted here; the keep/drop behavior itself is pinned by the regression testset above): when auto-prune drops an interpolator a discrete-event callback still needs, the callback goes silent -- the concrete failure being PBL mixing stalling so emitted NOx is trapped at the surface and titrates O3. The callback-aware (2-arg) prune keeps callback-needed fields live.

---

*Part of the coordinated cross-repo update tracked in EarthSciML/GasChem.jl#225.*
