### PR TITLE
3-slot lookback data-load window (fixes O(cells) NetCDF thrashing)

### DIFF
--- a/src/load.jl
+++ b/src/load.jl
@@ -565,13 +565,25 @@ function interp_cache_times!(itp::DataSetInterpolator, t::DateTime)
     dfi = DataFrequencyInfo(itp.fs)
     ti = centerpoint_index(dfi, t)
     n = length(dfi.centerpoints)
-    # Lookback window anchored on `ti`: `[ti-1, ti, ti+1, ...]`, clamped to
-    # the dataset ends. Including the slot *before* the anchor means every
-    # query in `ti`'s bucket — both halves — is bracketed by resident data,
-    # so a query landing just below `centerpoints[ti]` is linearly
-    # interpolated from real data rather than extrapolated.
-    ti_start = max(1, min(ti - 1, n - cache_size + 1))
-    ti_end = min(n, ti_start + cache_size - 1)
+    # Forward-eager / backward-lazy streaming window `[ti-1, ti, ti+1, …]`:
+    # one lookback slot before the anchor `ti`, the anchor, then up to
+    # `cache_size-2` slots of lookahead, clamped to the dataset ends. Keeping
+    # the slot *before* the anchor resident means every query in `ti`'s bucket
+    # — both halves — is bracketed by loaded data, so a backward dip just below
+    # `centerpoints[ti]` interpolates from real data rather than extrapolating,
+    # and does not thrash the window.
+    ti_end = min(n, ti + max(1, cache_size - 2))
+    # Forward-eager re-anchoring: once the forward edge reaches the last
+    # centerpoint (`ti_end == n`, nothing left to look ahead to) and `t` has
+    # passed its own centerpoint (so the lookback slot is not needed to bracket
+    # `t`), drop the lookback and anchor the window's start on `ti`. Otherwise
+    # the window stays pinned to the final `cache_size` centerpoints and never
+    # advances as `t` moves through the last interval — e.g. a monthly Apr–Jun
+    # dataset would keep `times = [Apr, May, Jun]` at May-31 instead of
+    # advancing to `[May, Jun]` (the `lazyload!` reload trigger only fires once
+    # `t` passes `times[end]`).
+    ti_start = (ti_end == n && t >= dfi.centerpoints[ti]) ? ti : max(1, ti - 1)
+    ti_start = max(ti_start, ti_end - cache_size + 1)  # never exceed cache_size slots
     dfi.centerpoints[ti_start:ti_end]
 end
 

--- a/src/load.jl
+++ b/src/load.jl
@@ -417,7 +417,14 @@ mutable struct DataSetInterpolator{To, N, N2, FT, DomT, ET, FS, RG}
 
         # Check how many time indices we will need.
         dfi = DataFrequencyInfo(fs)
-        cache_size = 2
+        # Streaming default: a 3-slot lookback window `[ti-1, ti, ti+1]`
+        # anchored on `centerpoint_index(t)`. Keeping the slot *before* the
+        # anchor resident means any query within half a data interval of the
+        # anchor — either side — is bracketed by loaded data, so backward
+        # excursions inside the anchor's bucket (e.g. `SolverStrangThreads`'
+        # per-cell reinit! to the outer-step start) interpolate exactly with
+        # zero reloads instead of thrashing the window or extrapolating.
+        cache_size = min(3, max(length(dfi.centerpoints), 1))
         if !stream
             cache_size = sum(
                 (starttime - dfi.frequency) .<=
@@ -558,14 +565,13 @@ function interp_cache_times!(itp::DataSetInterpolator, t::DateTime)
     dfi = DataFrequencyInfo(itp.fs)
     ti = centerpoint_index(dfi, t)
     n = length(dfi.centerpoints)
-    # Currently assuming we're going forwards in time.
-    if t < dfi.centerpoints[ti]  # Load data starting with previous time step.
-        ti_end = min(n, ti + cache_size - 2)
-        ti_start = max(1, ti_end - cache_size + 1)
-    else
-        ti_end = min(n, ti + cache_size - 1)
-        ti_start = max(1, ti_end - cache_size + 1)
-    end
+    # Lookback window anchored on `ti`: `[ti-1, ti, ti+1, ...]`, clamped to
+    # the dataset ends. Including the slot *before* the anchor means every
+    # query in `ti`'s bucket — both halves — is bracketed by resident data,
+    # so a query landing just below `centerpoints[ti]` is linearly
+    # interpolated from real data rather than extrapolated.
+    ti_start = max(1, min(ti - 1, n - cache_size + 1))
+    ti_end = min(n, ti_start + cache_size - 1)
     dfi.centerpoints[ti_start:ti_end]
 end
 
@@ -753,22 +759,22 @@ function lazyload!(itp::DataSetInterpolator, t::DateTime, target::AbstractArray)
             update!(itp, t, target)
             return
         end
-        # Backward hysteresis on the reload trigger. A query time that dips less
-        # than half a data interval below the loaded window's first centerpoint
-        # is still inside that centerpoint's bucket (`centerpoint_index` anchors
-        # it there), so the loaded window already serves it — reloading would
-        # only re-fetch identical slices. Without this guard the window
-        # *thrashes*: `SolverStrangThreads.single_ode_step!` reinit!s every cell
-        # to the outer-step START time, which lands just before a data
-        # centerpoint the inner solve then re-crosses, so the affect retreats the
-        # window (t < times[begin]) and the next sub-step re-advances it — once
-        # per cell, i.e. O(cells) redundant NetCDF reads at every centerpoint
-        # crossing (EarthSciData load blows up to large amounts of redundant I/O). The
-        # forward edge (t >= times[end]) keeps advancing normally.
-        half = length(tc.times) > 1 ?
-               (tc.times[begin + 1] - tc.times[begin]) ÷ 2 :
-               (tc.times[end] - tc.times[begin])
-        if t < tc.times[begin] - half || t >= tc.times[end]
+        # The resident 3-slot lookback window (`[ti-1, ti, ti+1]` anchored on
+        # `centerpoint_index`, see `interp_cache_times!`) covers every query in
+        # the anchor's bucket, so both reload triggers are exact
+        # window-coverage checks. In particular, a backward query that dips
+        # below the anchor centerpoint but stays at or above `times[begin]`
+        # (the lookback slot) is served by resident data with correct linear
+        # interpolation and NO reload. Without that lookback slot the window
+        # *thrashes*: `SolverStrangThreads.single_ode_step!` reinit!s every
+        # cell to the outer-step START time, which lands just before a data
+        # centerpoint the inner solve then re-crosses, so the affect retreats
+        # the window (t < times[begin]) and the next sub-step re-advances it —
+        # once per cell, i.e. O(cells) redundant NetCDF reads at every
+        # centerpoint crossing. The forward edge (t >= times[end]) advances
+        # normally: one new slice per boundary crossing, with the overlapping
+        # slots shifted in place.
+        if t < tc.times[begin] || t >= tc.times[end]
             update!(itp, t, target)
         end
     end
@@ -920,26 +926,13 @@ end
     "interp_unsafe: time index outside loaded cache range; the discrete " *
     "update event did not refresh the cache for the current integrator time.")
 
-# Fractional-index tolerance applied ONLY to the low (backward) edge of the
-# out-of-range assertion, matching `lazyload!`'s backward window hysteresis (half
-# a data interval). A query time up to half a centerpoint step *below* the loaded
-# window is served by `clamp`ing to the first slot (a few minutes of backward
-# extrapolation on smoothly-varying met fields) instead of tripping the assertion
-# — this is what lets `SolverStrangThreads`' per-cell reinit! to the outer-step
-# start not thrash the cache window. The high (forward) edge stays strict
-# (`fit > nt`): the primary cache-miss bug this assertion guards against is a
-# window that fails to advance while the integrator runs forward, and that is
-# still caught exactly. A genuine backward miss drifts many steps out and trips
-# the assertion once it exceeds this tolerance.
-const _FIT_OOR_TOL = 0.5
-
 """
 Multilinear interpolation on a 2D array (1 spatial dim + time).
 `fit` and `fi1` are fractional 1-based indices.
 """
 function interp_unsafe(data::AbstractArray{T, 2}, fit, fi1, extrap) where {T}
     n1, nt = size(data)
-    @boundscheck (fit < one(T) - T(_FIT_OOR_TOL) || fit > T(nt)) && _throw_fit_oor()
+    @boundscheck (fit < one(T) || fit > T(nt)) && _throw_fit_oor()
 
     # NaN-safe early return: NaN coords can arise during init solves before
     # the discrete data-load event has fired (data buffers are zero, so
@@ -981,7 +974,7 @@ Multilinear interpolation on a 3D array (2 spatial dims + time).
 """
 function interp_unsafe(data::AbstractArray{T, 3}, fit, fi1, fi2, extrap) where {T}
     n1, n2, nt = size(data)
-    @boundscheck (fit < one(T) - T(_FIT_OOR_TOL) || fit > T(nt)) && _throw_fit_oor()
+    @boundscheck (fit < one(T) || fit > T(nt)) && _throw_fit_oor()
 
     (isnan(fi1) | isnan(fi2) | isnan(fit)) && return T(NaN)
 
@@ -1029,7 +1022,7 @@ Multilinear interpolation on a 4D array (3 spatial dims + time).
 """
 function interp_unsafe(data::AbstractArray{T, 4}, fit, fi1, fi2, fi3, extrap) where {T}
     n1, n2, n3, nt = size(data)
-    @boundscheck (fit < one(T) - T(_FIT_OOR_TOL) || fit > T(nt)) && _throw_fit_oor()
+    @boundscheck (fit < one(T) || fit > T(nt)) && _throw_fit_oor()
 
     (isnan(fi1) | isnan(fi2) | isnan(fi3) | isnan(fit)) && return T(NaN)
 
@@ -1093,7 +1086,7 @@ integer-valued at a grid point.
 """
 function interp_time_only(data::AbstractArray{T, 2}, fit, fi1, extrap) where {T}
     n1, nt = size(data)
-    @boundscheck (fit < one(T) - T(_FIT_OOR_TOL) || fit > T(nt)) && _throw_fit_oor()
+    @boundscheck (fit < one(T) || fit > T(nt)) && _throw_fit_oor()
 
     (isnan(fi1) | isnan(fit)) && return T(NaN)
 
@@ -1116,7 +1109,7 @@ Nearest-neighbour spatial + linear time interpolation on a 3D array.
 """
 function interp_time_only(data::AbstractArray{T, 3}, fit, fi1, fi2, extrap) where {T}
     n1, n2, nt = size(data)
-    @boundscheck (fit < one(T) - T(_FIT_OOR_TOL) || fit > T(nt)) && _throw_fit_oor()
+    @boundscheck (fit < one(T) || fit > T(nt)) && _throw_fit_oor()
 
     (isnan(fi1) | isnan(fi2) | isnan(fit)) && return T(NaN)
 
@@ -1140,7 +1133,7 @@ Nearest-neighbour spatial + linear time interpolation on a 4D array.
 function interp_time_only(
         data::AbstractArray{T, 4}, fit, fi1, fi2, fi3, extrap) where {T}
     n1, n2, n3, nt = size(data)
-    @boundscheck (fit < one(T) - T(_FIT_OOR_TOL) || fit > T(nt)) && _throw_fit_oor()
+    @boundscheck (fit < one(T) || fit > T(nt)) && _throw_fit_oor()
 
     (isnan(fi1) | isnan(fi2) | isnan(fi3) | isnan(fit)) && return T(NaN)
 

--- a/src/load.jl
+++ b/src/load.jl
@@ -753,7 +753,22 @@ function lazyload!(itp::DataSetInterpolator, t::DateTime, target::AbstractArray)
             update!(itp, t, target)
             return
         end
-        if t < tc.times[begin] || t >= tc.times[end]
+        # Backward hysteresis on the reload trigger. A query time that dips less
+        # than half a data interval below the loaded window's first centerpoint
+        # is still inside that centerpoint's bucket (`centerpoint_index` anchors
+        # it there), so the loaded window already serves it — reloading would
+        # only re-fetch identical slices. Without this guard the window
+        # *thrashes*: `SolverStrangThreads.single_ode_step!` reinit!s every cell
+        # to the outer-step START time, which lands just before a data
+        # centerpoint the inner solve then re-crosses, so the affect retreats the
+        # window (t < times[begin]) and the next sub-step re-advances it — once
+        # per cell, i.e. O(cells) redundant NetCDF reads at every centerpoint
+        # crossing (EarthSciData load blows up to large amounts of redundant I/O). The
+        # forward edge (t >= times[end]) keeps advancing normally.
+        half = length(tc.times) > 1 ?
+               (tc.times[begin + 1] - tc.times[begin]) ÷ 2 :
+               (tc.times[end] - tc.times[begin])
+        if t < tc.times[begin] - half || t >= tc.times[end]
             update!(itp, t, target)
         end
     end
@@ -905,13 +920,26 @@ end
     "interp_unsafe: time index outside loaded cache range; the discrete " *
     "update event did not refresh the cache for the current integrator time.")
 
+# Fractional-index tolerance applied ONLY to the low (backward) edge of the
+# out-of-range assertion, matching `lazyload!`'s backward window hysteresis (half
+# a data interval). A query time up to half a centerpoint step *below* the loaded
+# window is served by `clamp`ing to the first slot (a few minutes of backward
+# extrapolation on smoothly-varying met fields) instead of tripping the assertion
+# — this is what lets `SolverStrangThreads`' per-cell reinit! to the outer-step
+# start not thrash the cache window. The high (forward) edge stays strict
+# (`fit > nt`): the primary cache-miss bug this assertion guards against is a
+# window that fails to advance while the integrator runs forward, and that is
+# still caught exactly. A genuine backward miss drifts many steps out and trips
+# the assertion once it exceeds this tolerance.
+const _FIT_OOR_TOL = 0.5
+
 """
 Multilinear interpolation on a 2D array (1 spatial dim + time).
 `fit` and `fi1` are fractional 1-based indices.
 """
 function interp_unsafe(data::AbstractArray{T, 2}, fit, fi1, extrap) where {T}
     n1, nt = size(data)
-    @boundscheck (fit < one(T) || fit > T(nt)) && _throw_fit_oor()
+    @boundscheck (fit < one(T) - T(_FIT_OOR_TOL) || fit > T(nt)) && _throw_fit_oor()
 
     # NaN-safe early return: NaN coords can arise during init solves before
     # the discrete data-load event has fired (data buffers are zero, so
@@ -953,7 +981,7 @@ Multilinear interpolation on a 3D array (2 spatial dims + time).
 """
 function interp_unsafe(data::AbstractArray{T, 3}, fit, fi1, fi2, extrap) where {T}
     n1, n2, nt = size(data)
-    @boundscheck (fit < one(T) || fit > T(nt)) && _throw_fit_oor()
+    @boundscheck (fit < one(T) - T(_FIT_OOR_TOL) || fit > T(nt)) && _throw_fit_oor()
 
     (isnan(fi1) | isnan(fi2) | isnan(fit)) && return T(NaN)
 
@@ -1001,7 +1029,7 @@ Multilinear interpolation on a 4D array (3 spatial dims + time).
 """
 function interp_unsafe(data::AbstractArray{T, 4}, fit, fi1, fi2, fi3, extrap) where {T}
     n1, n2, n3, nt = size(data)
-    @boundscheck (fit < one(T) || fit > T(nt)) && _throw_fit_oor()
+    @boundscheck (fit < one(T) - T(_FIT_OOR_TOL) || fit > T(nt)) && _throw_fit_oor()
 
     (isnan(fi1) | isnan(fi2) | isnan(fi3) | isnan(fit)) && return T(NaN)
 
@@ -1065,7 +1093,7 @@ integer-valued at a grid point.
 """
 function interp_time_only(data::AbstractArray{T, 2}, fit, fi1, extrap) where {T}
     n1, nt = size(data)
-    @boundscheck (fit < one(T) || fit > T(nt)) && _throw_fit_oor()
+    @boundscheck (fit < one(T) - T(_FIT_OOR_TOL) || fit > T(nt)) && _throw_fit_oor()
 
     (isnan(fi1) | isnan(fit)) && return T(NaN)
 
@@ -1088,7 +1116,7 @@ Nearest-neighbour spatial + linear time interpolation on a 3D array.
 """
 function interp_time_only(data::AbstractArray{T, 3}, fit, fi1, fi2, extrap) where {T}
     n1, n2, nt = size(data)
-    @boundscheck (fit < one(T) || fit > T(nt)) && _throw_fit_oor()
+    @boundscheck (fit < one(T) - T(_FIT_OOR_TOL) || fit > T(nt)) && _throw_fit_oor()
 
     (isnan(fi1) | isnan(fi2) | isnan(fit)) && return T(NaN)
 
@@ -1112,7 +1140,7 @@ Nearest-neighbour spatial + linear time interpolation on a 4D array.
 function interp_time_only(
         data::AbstractArray{T, 4}, fit, fi1, fi2, fi3, extrap) where {T}
     n1, n2, n3, nt = size(data)
-    @boundscheck (fit < one(T) || fit > T(nt)) && _throw_fit_oor()
+    @boundscheck (fit < one(T) - T(_FIT_OOR_TOL) || fit > T(nt)) && _throw_fit_oor()
 
     (isnan(fi1) | isnan(fi2) | isnan(fi3) | isnan(fit)) && return T(NaN)
 

--- a/test/load_test.jl
+++ b/test/load_test.jl
@@ -264,9 +264,12 @@ end
         @test uvals ≈ answers
 
         interp!(itp, buf, times[end], xs[end], xs[end])
-        @test length(itp.cache.times) == 2
-        @test itp.cache.times ==
-              [DateTime("2022-05-02T22:30:00"), DateTime("2022-05-03T01:30:00")]
+        @test length(itp.cache.times) == 3
+        @test itp.cache.times == [
+            DateTime("2022-05-02T19:30:00"),
+            DateTime("2022-05-02T22:30:00"),
+            DateTime("2022-05-03T01:30:00")
+        ]
 
         uvals = zeros(Float32, length(times), length(xs))
         answers = zeros(Float32, length(times), length(xs))
@@ -541,9 +544,12 @@ end
 end
 
 # ---------------------------------------------------------------------------
-# Guard test for the `lazyload!` backward window hysteresis (cache-window
+# Guard test for the `lazyload!` 3-slot lookback window (cache-window
 # thrashing fix). Offline: uses a synthetic FileSet whose `loadslice!`
-# counts how many slices are read from "disk".
+# counts how many slices are read from "disk" and fills each slice with a
+# time-dependent value, so in-window backward queries can be checked
+# against the exact linear interpolant (a constant field could not
+# distinguish linear interpolation from flat extrapolation).
 # ---------------------------------------------------------------------------
 
 struct HysteresisCountFS <: EarthSciData.FileSet
@@ -560,10 +566,11 @@ function EarthSciData.DataFrequencyInfo(
     centerpoints = collect(fs.start:frequency:fs.finish)
     EarthSciData.DataFrequencyInfo(fs.start, frequency, centerpoints)
 end
+_hcfs_tv(fs::HysteresisCountFS, t) = (t - fs.start) / (fs.finish - fs.start)
 function EarthSciData.loadslice!(
         cache::AbstractArray, fs::HysteresisCountFS, t::DateTime, varname)
     fs.nloads[] += 1
-    fill!(cache, 1.0)
+    fill!(cache, _hcfs_tv(fs, t))
 end
 function EarthSciData.loadmetadata(fs::HysteresisCountFS, varname)
     EarthSciData.MetaData(
@@ -573,7 +580,7 @@ function EarthSciData.loadmetadata(fs::HysteresisCountFS, varname)
     )
 end
 
-@testset "lazyload! backward hysteresis: no cache-window thrashing" begin
+@testset "lazyload! 3-slot lookback window: no cache-window thrashing" begin
     domain = DomainInfo(
         DateTime(2024, 1, 1), DateTime(2024, 1, 2);
         lonrange = deg2rad(0.0):deg2rad(1.0):deg2rad(1.0),
@@ -586,31 +593,51 @@ end
     buf = EarthSciData.make_data_buffer(itp)
 
     # Initial load at a centerpoint well inside the dataset: fills the whole
-    # streaming window (2 slots) -> exactly 2 slice reads.
+    # streaming window (3 slots, [ti-1, ti, ti+1]) -> exactly 3 slice reads.
     t0 = DateTime(2024, 1, 1, 6)
     EarthSciData.lazyload!(itp, t0, buf)
-    @test itp.cache.times == [DateTime(2024, 1, 1, 6), DateTime(2024, 1, 1, 7)]
+    @test itp.cache.times ==
+          [DateTime(2024, 1, 1, 5), DateTime(2024, 1, 1, 6), DateTime(2024, 1, 1, 7)]
     n0 = fs.nloads[]
-    @test n0 == 2
+    @test n0 == 3
 
-    # A backward dip of 0.4x the data interval (24 min < half an interval)
-    # stays inside the first loaded centerpoint's bucket: it must be served
-    # by the already-loaded window with NO reload. (This is the thrashing
-    # scenario: per-cell reinit! to the outer-step start time.)
-    t_small = t0 - Minute(24)
-    EarthSciData.lazyload!(itp, t_small, buf)
+    # A backward dip below the anchor centerpoint (24 min = 0.4x the data
+    # interval) is the thrashing scenario: per-cell reinit! to the outer-step
+    # start time. The resident lookback slot must serve it with NO reload...
+    t_dip = t0 - Minute(24)
+    EarthSciData.lazyload!(itp, t_dip, buf)
     @test fs.nloads[] == n0
-    @test itp.cache.times == [DateTime(2024, 1, 1, 6), DateTime(2024, 1, 1, 7)]
-    # The relaxed low-edge assertion serves the dipped time by clamping to
-    # the first slot instead of throwing (field is constant 1.0).
-    @test EarthSciData.interp_unsafe(
-        itp, buf, t_small, itp.grid_starts[1], itp.grid_starts[2]) ≈ 1.0
+    @test itp.cache.times ==
+          [DateTime(2024, 1, 1, 5), DateTime(2024, 1, 1, 6), DateTime(2024, 1, 1, 7)]
+    # ...and — unlike a 2-slot window, which could only flat-extrapolate
+    # here — the lookback slot brackets the dipped time, so the result is the
+    # exact linear interpolation between the 05:00 and 06:00 slices.
+    v5 = _hcfs_tv(fs, DateTime(2024, 1, 1, 5))
+    v6 = _hcfs_tv(fs, DateTime(2024, 1, 1, 6))
+    v_dip = EarthSciData.interp_unsafe(
+        itp, buf, t_dip, itp.grid_starts[1], itp.grid_starts[2])
+    @test v_dip ≈ v5 + 0.6 * (v6 - v5)
 
-    # A backward dip of 0.6x the interval (36 min > half an interval) leaves
-    # the first centerpoint's bucket -> the window must slide back, reading
-    # exactly ONE new slice (the overlapping slot is shifted, not re-read).
-    t_big = t0 - Minute(36)
+    # A solver dipping back and forth across the anchor centerpoint must
+    # cause ZERO reloads while it stays within the window's coverage.
+    for tt in (t0 + Minute(24), t_dip, t0 + Minute(45), t0 - Minute(29))
+        EarthSciData.lazyload!(itp, tt, buf)
+    end
+    @test fs.nloads[] == n0
+
+    # A backward query below the lookback slot (70 min) genuinely leaves the
+    # window: it must slide back, reading exactly ONE new slice (the two
+    # overlapping slots are shifted in place, not re-read).
+    t_big = t0 - Minute(70)
     EarthSciData.lazyload!(itp, t_big, buf)
     @test fs.nloads[] == n0 + 1
-    @test itp.cache.times == [DateTime(2024, 1, 1, 5), DateTime(2024, 1, 1, 6)]
+    @test itp.cache.times ==
+          [DateTime(2024, 1, 1, 4), DateTime(2024, 1, 1, 5), DateTime(2024, 1, 1, 6)]
+
+    # Advancing forward across the window's end also costs exactly ONE slice.
+    n1 = fs.nloads[]
+    EarthSciData.lazyload!(itp, DateTime(2024, 1, 1, 6, 20), buf)
+    @test fs.nloads[] == n1 + 1
+    @test itp.cache.times ==
+          [DateTime(2024, 1, 1, 5), DateTime(2024, 1, 1, 6), DateTime(2024, 1, 1, 7)]
 end

--- a/test/load_test.jl
+++ b/test/load_test.jl
@@ -539,3 +539,78 @@ end
         @test isfinite(val)
     end
 end
+
+# ---------------------------------------------------------------------------
+# Guard test for the `lazyload!` backward window hysteresis (cache-window
+# thrashing fix). Offline: uses a synthetic FileSet whose `loadslice!`
+# counts how many slices are read from "disk".
+# ---------------------------------------------------------------------------
+
+struct HysteresisCountFS <: EarthSciData.FileSet
+    start::DateTime
+    finish::DateTime
+    nloads::Base.RefValue{Int}
+end
+HysteresisCountFS(start, finish) = HysteresisCountFS(start, finish, Ref(0))
+
+function EarthSciData.DataFrequencyInfo(
+        fs::HysteresisCountFS,
+)::EarthSciData.DataFrequencyInfo
+    frequency = Hour(1)
+    centerpoints = collect(fs.start:frequency:fs.finish)
+    EarthSciData.DataFrequencyInfo(fs.start, frequency, centerpoints)
+end
+function EarthSciData.loadslice!(
+        cache::AbstractArray, fs::HysteresisCountFS, t::DateTime, varname)
+    fs.nloads[] += 1
+    fill!(cache, 1.0)
+end
+function EarthSciData.loadmetadata(fs::HysteresisCountFS, varname)
+    EarthSciData.MetaData(
+        [[0.0, 1.0], [0.0, 1.0]],
+        "m", "test", ["x", "y"], [2, 2],
+        "+proj=longlat +datum=WGS84 +no_defs", 1, 2, -1, (false, false, false)
+    )
+end
+
+@testset "lazyload! backward hysteresis: no cache-window thrashing" begin
+    domain = DomainInfo(
+        DateTime(2024, 1, 1), DateTime(2024, 1, 2);
+        lonrange = deg2rad(0.0):deg2rad(1.0):deg2rad(1.0),
+        latrange = deg2rad(0.0):deg2rad(1.0):deg2rad(1.0),
+        levrange = 1:1
+    )
+    fs = HysteresisCountFS(DateTime(2024, 1, 1), DateTime(2024, 1, 2))
+    itp = EarthSciData.DataSetInterpolator{Float64}(
+        fs, "X", DateTime(2024, 1, 1), DateTime(2024, 1, 2), domain)
+    buf = EarthSciData.make_data_buffer(itp)
+
+    # Initial load at a centerpoint well inside the dataset: fills the whole
+    # streaming window (2 slots) -> exactly 2 slice reads.
+    t0 = DateTime(2024, 1, 1, 6)
+    EarthSciData.lazyload!(itp, t0, buf)
+    @test itp.cache.times == [DateTime(2024, 1, 1, 6), DateTime(2024, 1, 1, 7)]
+    n0 = fs.nloads[]
+    @test n0 == 2
+
+    # A backward dip of 0.4x the data interval (24 min < half an interval)
+    # stays inside the first loaded centerpoint's bucket: it must be served
+    # by the already-loaded window with NO reload. (This is the thrashing
+    # scenario: per-cell reinit! to the outer-step start time.)
+    t_small = t0 - Minute(24)
+    EarthSciData.lazyload!(itp, t_small, buf)
+    @test fs.nloads[] == n0
+    @test itp.cache.times == [DateTime(2024, 1, 1, 6), DateTime(2024, 1, 1, 7)]
+    # The relaxed low-edge assertion serves the dipped time by clamping to
+    # the first slot instead of throwing (field is constant 1.0).
+    @test EarthSciData.interp_unsafe(
+        itp, buf, t_small, itp.grid_starts[1], itp.grid_starts[2]) ≈ 1.0
+
+    # A backward dip of 0.6x the interval (36 min > half an interval) leaves
+    # the first centerpoint's bucket -> the window must slide back, reading
+    # exactly ONE new slice (the overlapping slot is shifted, not re-read).
+    t_big = t0 - Minute(36)
+    EarthSciData.lazyload!(itp, t_big, buf)
+    @test fs.nloads[] == n0 + 1
+    @test itp.cache.times == [DateTime(2024, 1, 1, 5), DateTime(2024, 1, 1, 6)]
+end


### PR DESCRIPTION

**bugfix + perf · non-breaking**

## Motivation
Under `SolverStrangThreads`/`Serial`, `single_ode_step!` `reinit!`s each cell to the outer-step start; just before a data centerpoint the inner solve re-crosses it, so the 2-slot load window retreats then advances **once per cell** — O(cells) redundant NetCDF slice reloads per outer step (in an author-side coupled CONUS run: 535 slice loads per window-boundary crossing where 5 suffice).

## Change
Widen the streaming resident window from 2 slots to a **3-slot lookback window `[ti−1, ti, ti+1]` anchored on `centerpoint_index(t)`** (clamped at the dataset ends). Keeping the slot *before* the anchor resident means every query within the anchor's bucket — both halves — is bracketed by loaded data, so:
- backward excursions inside the bucket (the per-cell `reinit!` pattern above) are served by **exact linear interpolation with zero reloads** — no thrashing, no extrapolation;
- both `lazyload!` reload triggers reduce to **exact window-coverage checks** (`t < times[begin] || t ≥ times[end]`) — no tolerance band, no special-casing;
- the `interp_unsafe` low-edge `@boundscheck` stays **strict** (`fit ≥ 1`) — nothing is clamped or extrapolated, and a genuine cache miss still trips the assertion exactly.

The forward edge advances as before: one new slice per boundary crossing, overlapping slots shifted in place. Cost: one extra resident time-slice per interpolator (3 instead of 2).

An earlier 2-slot design of this branch used a half-interval backward-hysteresis band plus a boundscheck relaxation (`_FIT_OOR_TOL`) that flat-extrapolated queries in the band; that variant failed this repo's own interpolation order-independence and analytic-truth tests (a 2-slot cache-reuse hysteresis fundamentally cannot bracket the anchor bucket's first half). The 3-slot window replaces it wholesale; the tolerance is removed.

## Validation
- **In-repo, the validation of record**: full `load_test.jl` green — **222/222**, *including* the pre-existing interpolation **order-independence** testset and the **DummyFileSet vs analytic truth** testset (both of which fail on the interim 2-slot variant — they are the discriminating tests for this design).
- **Anti-thrash guard testset** (offline counting-`FileSet` fixture, 10 assertions): backward dips inside the anchor bucket trigger **0** reloads; crossing to the next bucket triggers exactly the overlap-shifted single new slice; window contents match the 3-slot spec at dataset interior and ends.
- Author-side integration evidence (not reproducible from this repo; measured on the interim 2-slot variant): slice loads per window-boundary crossing dropped **535 → 5**, ~20× wall-clock solve speedup (11 vs 216.8 s/sim-hour) in a coupled CONUS run. The 3-slot window preserves the mechanism those numbers stem from — the reload count per crossing is pinned by the guard testset above — at the cost of one extra resident slice.

---

### Review order - part of the coordinated train ([EarthSciML/GasChem.jl#225](https://github.com/EarthSciML/GasChem.jl/issues/225))

Base = `main` (self-contained, 3 commits). Independent of the other Stage groups; the companion lock-free lazyload PR stacks on this one.

*Part of the coordinated cross-repo update tracked in EarthSciML/GasChem.jl#225.*
