### PR TITLE
Lock-free fast path in lazyload! + affect NamedTuple cache-by-t_abs

### DIFF
--- a/src/load.jl
+++ b/src/load.jl
@@ -565,13 +565,25 @@ function interp_cache_times!(itp::DataSetInterpolator, t::DateTime)
     dfi = DataFrequencyInfo(itp.fs)
     ti = centerpoint_index(dfi, t)
     n = length(dfi.centerpoints)
-    # Lookback window anchored on `ti`: `[ti-1, ti, ti+1, ...]`, clamped to
-    # the dataset ends. Including the slot *before* the anchor means every
-    # query in `ti`'s bucket — both halves — is bracketed by resident data,
-    # so a query landing just below `centerpoints[ti]` is linearly
-    # interpolated from real data rather than extrapolated.
-    ti_start = max(1, min(ti - 1, n - cache_size + 1))
-    ti_end = min(n, ti_start + cache_size - 1)
+    # Forward-eager / backward-lazy streaming window `[ti-1, ti, ti+1, …]`:
+    # one lookback slot before the anchor `ti`, the anchor, then up to
+    # `cache_size-2` slots of lookahead, clamped to the dataset ends. Keeping
+    # the slot *before* the anchor resident means every query in `ti`'s bucket
+    # — both halves — is bracketed by loaded data, so a backward dip just below
+    # `centerpoints[ti]` interpolates from real data rather than extrapolating,
+    # and does not thrash the window.
+    ti_end = min(n, ti + max(1, cache_size - 2))
+    # Forward-eager re-anchoring: once the forward edge reaches the last
+    # centerpoint (`ti_end == n`, nothing left to look ahead to) and `t` has
+    # passed its own centerpoint (so the lookback slot is not needed to bracket
+    # `t`), drop the lookback and anchor the window's start on `ti`. Otherwise
+    # the window stays pinned to the final `cache_size` centerpoints and never
+    # advances as `t` moves through the last interval — e.g. a monthly Apr–Jun
+    # dataset would keep `times = [Apr, May, Jun]` at May-31 instead of
+    # advancing to `[May, Jun]` (the `lazyload!` reload trigger only fires once
+    # `t` passes `times[end]`).
+    ti_start = (ti_end == n && t >= dfi.centerpoints[ti]) ? ti : max(1, ti - 1)
+    ti_start = max(ti_start, ti_end - cache_size + 1)  # never exceed cache_size slots
     dfi.centerpoints[ti_start:ti_end]
 end
 

--- a/src/load.jl
+++ b/src/load.jl
@@ -761,6 +761,27 @@ function update!(itp::DataSetInterpolator, t::DateTime, target::AbstractArray)
 end
 
 function lazyload!(itp::DataSetInterpolator, t::DateTime, target::AbstractArray)
+    # Lock-free fast path. A reload is only needed once per data interval (per
+    # centerpoint crossing); the overwhelmingly common per-cell call finds the
+    # loaded window already covering `t`. Acquiring `itp.lock` on EVERY call
+    # serializes all solver threads on this shared per-interpolator lock — a
+    # non-issue at low thread counts but a hard scaling wall at high ones (a
+    # many solver threads then run slower than a few and the run can appear hung).
+    # `tc.times`/`tc.initialized` are mutated only inside `update!` under the
+    # lock, and DateTimes are immutable, so an unsynchronized read here is
+    # benign: a stale read at worst falls through to the locked slow path, which
+    # re-checks. When the loaded window already covers `t`, no reload is possible,
+    # so return without ever touching the lock. (Mirrors the slow-path guard
+    # below: within [times[begin] - half, times[end]) → no reload.)
+    let tc = itp.cache
+        if tc.initialized
+            times = tc.times
+            if length(times) > 1
+                half = (times[begin + 1] - times[begin]) ÷ 2
+                (times[begin] - half <= t < times[end]) && return itp
+            end
+        end
+    end
     lock(itp.lock) do
         tc = itp.cache
         if tc.currenttime == t

--- a/src/load.jl
+++ b/src/load.jl
@@ -417,7 +417,14 @@ mutable struct DataSetInterpolator{To, N, N2, FT, DomT, ET, FS, RG}
 
         # Check how many time indices we will need.
         dfi = DataFrequencyInfo(fs)
-        cache_size = 2
+        # Streaming default: a 3-slot lookback window `[ti-1, ti, ti+1]`
+        # anchored on `centerpoint_index(t)`. Keeping the slot *before* the
+        # anchor resident means any query within half a data interval of the
+        # anchor — either side — is bracketed by loaded data, so backward
+        # excursions inside the anchor's bucket (e.g. `SolverStrangThreads`'
+        # per-cell reinit! to the outer-step start) interpolate exactly with
+        # zero reloads instead of thrashing the window or extrapolating.
+        cache_size = min(3, max(length(dfi.centerpoints), 1))
         if !stream
             cache_size = sum(
                 (starttime - dfi.frequency) .<=
@@ -558,14 +565,13 @@ function interp_cache_times!(itp::DataSetInterpolator, t::DateTime)
     dfi = DataFrequencyInfo(itp.fs)
     ti = centerpoint_index(dfi, t)
     n = length(dfi.centerpoints)
-    # Currently assuming we're going forwards in time.
-    if t < dfi.centerpoints[ti]  # Load data starting with previous time step.
-        ti_end = min(n, ti + cache_size - 2)
-        ti_start = max(1, ti_end - cache_size + 1)
-    else
-        ti_end = min(n, ti + cache_size - 1)
-        ti_start = max(1, ti_end - cache_size + 1)
-    end
+    # Lookback window anchored on `ti`: `[ti-1, ti, ti+1, ...]`, clamped to
+    # the dataset ends. Including the slot *before* the anchor means every
+    # query in `ti`'s bucket — both halves — is bracketed by resident data,
+    # so a query landing just below `centerpoints[ti]` is linearly
+    # interpolated from real data rather than extrapolated.
+    ti_start = max(1, min(ti - 1, n - cache_size + 1))
+    ti_end = min(n, ti_start + cache_size - 1)
     dfi.centerpoints[ti_start:ti_end]
 end
 
@@ -753,22 +759,22 @@ function lazyload!(itp::DataSetInterpolator, t::DateTime, target::AbstractArray)
             update!(itp, t, target)
             return
         end
-        # Backward hysteresis on the reload trigger. A query time that dips less
-        # than half a data interval below the loaded window's first centerpoint
-        # is still inside that centerpoint's bucket (`centerpoint_index` anchors
-        # it there), so the loaded window already serves it — reloading would
-        # only re-fetch identical slices. Without this guard the window
-        # *thrashes*: `SolverStrangThreads.single_ode_step!` reinit!s every cell
-        # to the outer-step START time, which lands just before a data
-        # centerpoint the inner solve then re-crosses, so the affect retreats the
-        # window (t < times[begin]) and the next sub-step re-advances it — once
-        # per cell, i.e. O(cells) redundant NetCDF reads at every centerpoint
-        # crossing (EarthSciData load blows up to large amounts of redundant I/O). The
-        # forward edge (t >= times[end]) keeps advancing normally.
-        half = length(tc.times) > 1 ?
-               (tc.times[begin + 1] - tc.times[begin]) ÷ 2 :
-               (tc.times[end] - tc.times[begin])
-        if t < tc.times[begin] - half || t >= tc.times[end]
+        # The resident 3-slot lookback window (`[ti-1, ti, ti+1]` anchored on
+        # `centerpoint_index`, see `interp_cache_times!`) covers every query in
+        # the anchor's bucket, so both reload triggers are exact
+        # window-coverage checks. In particular, a backward query that dips
+        # below the anchor centerpoint but stays at or above `times[begin]`
+        # (the lookback slot) is served by resident data with correct linear
+        # interpolation and NO reload. Without that lookback slot the window
+        # *thrashes*: `SolverStrangThreads.single_ode_step!` reinit!s every
+        # cell to the outer-step START time, which lands just before a data
+        # centerpoint the inner solve then re-crosses, so the affect retreats
+        # the window (t < times[begin]) and the next sub-step re-advances it —
+        # once per cell, i.e. O(cells) redundant NetCDF reads at every
+        # centerpoint crossing. The forward edge (t >= times[end]) advances
+        # normally: one new slice per boundary crossing, with the overlapping
+        # slots shifted in place.
+        if t < tc.times[begin] || t >= tc.times[end]
             update!(itp, t, target)
         end
     end
@@ -920,26 +926,13 @@ end
     "interp_unsafe: time index outside loaded cache range; the discrete " *
     "update event did not refresh the cache for the current integrator time.")
 
-# Fractional-index tolerance applied ONLY to the low (backward) edge of the
-# out-of-range assertion, matching `lazyload!`'s backward window hysteresis (half
-# a data interval). A query time up to half a centerpoint step *below* the loaded
-# window is served by `clamp`ing to the first slot (a few minutes of backward
-# extrapolation on smoothly-varying met fields) instead of tripping the assertion
-# — this is what lets `SolverStrangThreads`' per-cell reinit! to the outer-step
-# start not thrash the cache window. The high (forward) edge stays strict
-# (`fit > nt`): the primary cache-miss bug this assertion guards against is a
-# window that fails to advance while the integrator runs forward, and that is
-# still caught exactly. A genuine backward miss drifts many steps out and trips
-# the assertion once it exceeds this tolerance.
-const _FIT_OOR_TOL = 0.5
-
 """
 Multilinear interpolation on a 2D array (1 spatial dim + time).
 `fit` and `fi1` are fractional 1-based indices.
 """
 function interp_unsafe(data::AbstractArray{T, 2}, fit, fi1, extrap) where {T}
     n1, nt = size(data)
-    @boundscheck (fit < one(T) - T(_FIT_OOR_TOL) || fit > T(nt)) && _throw_fit_oor()
+    @boundscheck (fit < one(T) || fit > T(nt)) && _throw_fit_oor()
 
     # NaN-safe early return: NaN coords can arise during init solves before
     # the discrete data-load event has fired (data buffers are zero, so
@@ -981,7 +974,7 @@ Multilinear interpolation on a 3D array (2 spatial dims + time).
 """
 function interp_unsafe(data::AbstractArray{T, 3}, fit, fi1, fi2, extrap) where {T}
     n1, n2, nt = size(data)
-    @boundscheck (fit < one(T) - T(_FIT_OOR_TOL) || fit > T(nt)) && _throw_fit_oor()
+    @boundscheck (fit < one(T) || fit > T(nt)) && _throw_fit_oor()
 
     (isnan(fi1) | isnan(fi2) | isnan(fit)) && return T(NaN)
 
@@ -1029,7 +1022,7 @@ Multilinear interpolation on a 4D array (3 spatial dims + time).
 """
 function interp_unsafe(data::AbstractArray{T, 4}, fit, fi1, fi2, fi3, extrap) where {T}
     n1, n2, n3, nt = size(data)
-    @boundscheck (fit < one(T) - T(_FIT_OOR_TOL) || fit > T(nt)) && _throw_fit_oor()
+    @boundscheck (fit < one(T) || fit > T(nt)) && _throw_fit_oor()
 
     (isnan(fi1) | isnan(fi2) | isnan(fi3) | isnan(fit)) && return T(NaN)
 
@@ -1093,7 +1086,7 @@ integer-valued at a grid point.
 """
 function interp_time_only(data::AbstractArray{T, 2}, fit, fi1, extrap) where {T}
     n1, nt = size(data)
-    @boundscheck (fit < one(T) - T(_FIT_OOR_TOL) || fit > T(nt)) && _throw_fit_oor()
+    @boundscheck (fit < one(T) || fit > T(nt)) && _throw_fit_oor()
 
     (isnan(fi1) | isnan(fit)) && return T(NaN)
 
@@ -1116,7 +1109,7 @@ Nearest-neighbour spatial + linear time interpolation on a 3D array.
 """
 function interp_time_only(data::AbstractArray{T, 3}, fit, fi1, fi2, extrap) where {T}
     n1, n2, nt = size(data)
-    @boundscheck (fit < one(T) - T(_FIT_OOR_TOL) || fit > T(nt)) && _throw_fit_oor()
+    @boundscheck (fit < one(T) || fit > T(nt)) && _throw_fit_oor()
 
     (isnan(fi1) | isnan(fi2) | isnan(fit)) && return T(NaN)
 
@@ -1140,7 +1133,7 @@ Nearest-neighbour spatial + linear time interpolation on a 4D array.
 function interp_time_only(
         data::AbstractArray{T, 4}, fit, fi1, fi2, fi3, extrap) where {T}
     n1, n2, n3, nt = size(data)
-    @boundscheck (fit < one(T) - T(_FIT_OOR_TOL) || fit > T(nt)) && _throw_fit_oor()
+    @boundscheck (fit < one(T) || fit > T(nt)) && _throw_fit_oor()
 
     (isnan(fi1) | isnan(fi2) | isnan(fi3) | isnan(fit)) && return T(NaN)
 

--- a/src/load.jl
+++ b/src/load.jl
@@ -753,7 +753,22 @@ function lazyload!(itp::DataSetInterpolator, t::DateTime, target::AbstractArray)
             update!(itp, t, target)
             return
         end
-        if t < tc.times[begin] || t >= tc.times[end]
+        # Backward hysteresis on the reload trigger. A query time that dips less
+        # than half a data interval below the loaded window's first centerpoint
+        # is still inside that centerpoint's bucket (`centerpoint_index` anchors
+        # it there), so the loaded window already serves it — reloading would
+        # only re-fetch identical slices. Without this guard the window
+        # *thrashes*: `SolverStrangThreads.single_ode_step!` reinit!s every cell
+        # to the outer-step START time, which lands just before a data
+        # centerpoint the inner solve then re-crosses, so the affect retreats the
+        # window (t < times[begin]) and the next sub-step re-advances it — once
+        # per cell, i.e. O(cells) redundant NetCDF reads at every centerpoint
+        # crossing (EarthSciData load blows up to large amounts of redundant I/O). The
+        # forward edge (t >= times[end]) keeps advancing normally.
+        half = length(tc.times) > 1 ?
+               (tc.times[begin + 1] - tc.times[begin]) ÷ 2 :
+               (tc.times[end] - tc.times[begin])
+        if t < tc.times[begin] - half || t >= tc.times[end]
             update!(itp, t, target)
         end
     end
@@ -905,13 +920,26 @@ end
     "interp_unsafe: time index outside loaded cache range; the discrete " *
     "update event did not refresh the cache for the current integrator time.")
 
+# Fractional-index tolerance applied ONLY to the low (backward) edge of the
+# out-of-range assertion, matching `lazyload!`'s backward window hysteresis (half
+# a data interval). A query time up to half a centerpoint step *below* the loaded
+# window is served by `clamp`ing to the first slot (a few minutes of backward
+# extrapolation on smoothly-varying met fields) instead of tripping the assertion
+# — this is what lets `SolverStrangThreads`' per-cell reinit! to the outer-step
+# start not thrash the cache window. The high (forward) edge stays strict
+# (`fit > nt`): the primary cache-miss bug this assertion guards against is a
+# window that fails to advance while the integrator runs forward, and that is
+# still caught exactly. A genuine backward miss drifts many steps out and trips
+# the assertion once it exceeds this tolerance.
+const _FIT_OOR_TOL = 0.5
+
 """
 Multilinear interpolation on a 2D array (1 spatial dim + time).
 `fit` and `fi1` are fractional 1-based indices.
 """
 function interp_unsafe(data::AbstractArray{T, 2}, fit, fi1, extrap) where {T}
     n1, nt = size(data)
-    @boundscheck (fit < one(T) || fit > T(nt)) && _throw_fit_oor()
+    @boundscheck (fit < one(T) - T(_FIT_OOR_TOL) || fit > T(nt)) && _throw_fit_oor()
 
     # NaN-safe early return: NaN coords can arise during init solves before
     # the discrete data-load event has fired (data buffers are zero, so
@@ -953,7 +981,7 @@ Multilinear interpolation on a 3D array (2 spatial dims + time).
 """
 function interp_unsafe(data::AbstractArray{T, 3}, fit, fi1, fi2, extrap) where {T}
     n1, n2, nt = size(data)
-    @boundscheck (fit < one(T) || fit > T(nt)) && _throw_fit_oor()
+    @boundscheck (fit < one(T) - T(_FIT_OOR_TOL) || fit > T(nt)) && _throw_fit_oor()
 
     (isnan(fi1) | isnan(fi2) | isnan(fit)) && return T(NaN)
 
@@ -1001,7 +1029,7 @@ Multilinear interpolation on a 4D array (3 spatial dims + time).
 """
 function interp_unsafe(data::AbstractArray{T, 4}, fit, fi1, fi2, fi3, extrap) where {T}
     n1, n2, n3, nt = size(data)
-    @boundscheck (fit < one(T) || fit > T(nt)) && _throw_fit_oor()
+    @boundscheck (fit < one(T) - T(_FIT_OOR_TOL) || fit > T(nt)) && _throw_fit_oor()
 
     (isnan(fi1) | isnan(fi2) | isnan(fi3) | isnan(fit)) && return T(NaN)
 
@@ -1065,7 +1093,7 @@ integer-valued at a grid point.
 """
 function interp_time_only(data::AbstractArray{T, 2}, fit, fi1, extrap) where {T}
     n1, nt = size(data)
-    @boundscheck (fit < one(T) || fit > T(nt)) && _throw_fit_oor()
+    @boundscheck (fit < one(T) - T(_FIT_OOR_TOL) || fit > T(nt)) && _throw_fit_oor()
 
     (isnan(fi1) | isnan(fit)) && return T(NaN)
 
@@ -1088,7 +1116,7 @@ Nearest-neighbour spatial + linear time interpolation on a 3D array.
 """
 function interp_time_only(data::AbstractArray{T, 3}, fit, fi1, fi2, extrap) where {T}
     n1, n2, nt = size(data)
-    @boundscheck (fit < one(T) || fit > T(nt)) && _throw_fit_oor()
+    @boundscheck (fit < one(T) - T(_FIT_OOR_TOL) || fit > T(nt)) && _throw_fit_oor()
 
     (isnan(fi1) | isnan(fi2) | isnan(fit)) && return T(NaN)
 
@@ -1112,7 +1140,7 @@ Nearest-neighbour spatial + linear time interpolation on a 4D array.
 function interp_time_only(
         data::AbstractArray{T, 4}, fit, fi1, fi2, fi3, extrap) where {T}
     n1, n2, n3, nt = size(data)
-    @boundscheck (fit < one(T) || fit > T(nt)) && _throw_fit_oor()
+    @boundscheck (fit < one(T) - T(_FIT_OOR_TOL) || fit > T(nt)) && _throw_fit_oor()
 
     (isnan(fi1) | isnan(fi2) | isnan(fi3) | isnan(fit)) && return T(NaN)
 

--- a/src/load.jl
+++ b/src/load.jl
@@ -772,13 +772,13 @@ function lazyload!(itp::DataSetInterpolator, t::DateTime, target::AbstractArray)
     # benign: a stale read at worst falls through to the locked slow path, which
     # re-checks. When the loaded window already covers `t`, no reload is possible,
     # so return without ever touching the lock. (Mirrors the slow-path guard
-    # below: within [times[begin] - half, times[end]) → no reload.)
+    # below exactly: within [times[begin], times[end]) → no reload — the
+    # 3-slot lookback window already brackets the whole anchor bucket.)
     let tc = itp.cache
         if tc.initialized
             times = tc.times
             if length(times) > 1
-                half = (times[begin + 1] - times[begin]) ÷ 2
-                (times[begin] - half <= t < times[end]) && return itp
+                (times[begin] <= t < times[end]) && return itp
             end
         end
     end

--- a/src/mtk_integration.jl
+++ b/src/mtk_integration.jl
@@ -646,8 +646,29 @@ function build_interp_event(interp_infos, starttime::DateTime)
     ts_buf = Vector{Float64}(undef, n_interp)
     tstep_buf = Vector{Float64}(undef, n_interp)
 
+    # Cache the last-built parameter NamedTuple, keyed by the absolute time it was
+    # built for. Under SolverStrangThreads every grid cell's `reinit!` fires this
+    # affect at the SAME `t_abs` within one outer step, so the built result is
+    # identical. Without caching, all solver threads serialize on `update_lock`
+    # AND allocate a fresh NamedTuple once per cell — the dominant high-thread
+    # scaling wall (more threads then run no faster than fewer). Repeat fires now return the
+    # cache with no lock and no allocation.
+    last_tabs = Ref(NaN)
+    cached_nt = Ref{Any}(nothing)
+
     function update_data!(_modified, _observed, ctx, integ)
+        t_abs = integ.t + t_ref
+        # Lock-free fast path: same t_abs as the last build → identical result.
+        if t_abs == last_tabs[]
+            c = cached_nt[]
+            c === nothing || return c
+        end
         lock(update_lock) do
+            # Double-check under the lock: another thread may have just built it.
+            if t_abs == last_tabs[]
+                c = cached_nt[]
+                c === nothing || return c
+            end
             if !prune_done[]
                 sys = isdefined(integ.f, :sys) ? integ.f.sys : nothing
                 if sys !== nothing
@@ -678,13 +699,15 @@ function build_interp_event(interp_infos, starttime::DateTime)
             # signal `data_wrappers[i] === nothing` replaces a
             # `modified[dkey]` probe whose heterogeneous-union return would
             # otherwise box.
-            t_abs = integ.t + t_ref
             for i in 1:n_interp
                 _update_one_interp!(interp_infos[i], ctx[i], t_abs,
                     data_wrappers, ts_buf, tstep_buf, i)
             end
-            _build_updates_nt(live_keys_val_ref[], live_idx_val_ref[],
+            nt = _build_updates_nt(live_keys_val_ref[], live_idx_val_ref[],
                 data_wrappers, ts_buf, tstep_buf)
+            last_tabs[] = t_abs
+            cached_nt[] = nt
+            nt
         end
     end
 

--- a/test/load_test.jl
+++ b/test/load_test.jl
@@ -664,14 +664,16 @@ end
         t0 = DateTime(2024, 1, 1, 6)
         EarthSciData.lazyload!(itp, t0, buf)
         n0 = fs.nloads[]
-        @test n0 == 2
+        @test n0 == 3   # 3-slot lookback window [ti-1, ti, ti+1]
         # Repeats at the unchanged time, plus covered times inside the loaded
-        # window, are all served by the lock-free fast path: NO reload.
+        # window (incl. the backward lookback slot at t0 - 20 min ≥ times[begin]),
+        # are all served by the lock-free fast path: NO reload.
         for tt in (t0, t0, t0 + Minute(10), t0 + Minute(45), t0 - Minute(20))
             EarthSciData.lazyload!(itp, tt, buf)
         end
         @test fs.nloads[] == n0
-        @test itp.cache.times == [DateTime(2024, 1, 1, 6), DateTime(2024, 1, 1, 7)]
+        @test itp.cache.times ==
+              [DateTime(2024, 1, 1, 5), DateTime(2024, 1, 1, 6), DateTime(2024, 1, 1, 7)]
     end
 
     @testset "affect NamedTuple is identical (===) for a repeated t_abs" begin

--- a/test/load_test.jl
+++ b/test/load_test.jl
@@ -641,3 +641,72 @@ end
     @test itp.cache.times ==
           [DateTime(2024, 1, 1, 5), DateTime(2024, 1, 1, 6), DateTime(2024, 1, 1, 7)]
 end
+
+# ---------------------------------------------------------------------------
+# Guard tests for the lock-free `lazyload!` fast path and the interp-event
+# affect NamedTuple cache (keyed by t_abs). Offline: reuses the counting
+# `HysteresisCountFS` fixture defined above.
+# ---------------------------------------------------------------------------
+
+@testset "lock-free lazyload! + interp-event affect NamedTuple cache" begin
+    domain = DomainInfo(
+        DateTime(2024, 1, 1), DateTime(2024, 1, 2);
+        lonrange = deg2rad(0.0):deg2rad(1.0):deg2rad(1.0),
+        latrange = deg2rad(0.0):deg2rad(1.0):deg2rad(1.0),
+        levrange = 1:1
+    )
+
+    @testset "repeated lazyload! at unchanged time performs no reload" begin
+        fs = HysteresisCountFS(DateTime(2024, 1, 1), DateTime(2024, 1, 2))
+        itp = EarthSciData.DataSetInterpolator{Float64}(
+            fs, "X", DateTime(2024, 1, 1), DateTime(2024, 1, 2), domain)
+        buf = EarthSciData.make_data_buffer(itp)
+        t0 = DateTime(2024, 1, 1, 6)
+        EarthSciData.lazyload!(itp, t0, buf)
+        n0 = fs.nloads[]
+        @test n0 == 2
+        # Repeats at the unchanged time, plus covered times inside the loaded
+        # window, are all served by the lock-free fast path: NO reload.
+        for tt in (t0, t0, t0 + Minute(10), t0 + Minute(45), t0 - Minute(20))
+            EarthSciData.lazyload!(itp, tt, buf)
+        end
+        @test fs.nloads[] == n0
+        @test itp.cache.times == [DateTime(2024, 1, 1, 6), DateTime(2024, 1, 1, 7)]
+    end
+
+    @testset "affect NamedTuple is identical (===) for a repeated t_abs" begin
+        fs = HysteresisCountFS(DateTime(2024, 1, 1), DateTime(2024, 1, 2))
+        starttime = DateTime(2024, 1, 1)
+        itp = EarthSciData.DataSetInterpolator{Float64}(
+            fs, "X", starttime, DateTime(2024, 1, 2), domain)
+        # Minimal interp_info (the NamedTuple shape built by
+        # `create_interp_equation`), restricted to the fields the event path
+        # touches.
+        @parameters lfx_data lfx_tstart lfx_tstep
+        info = (data_sym = lfx_data, tstart_sym = lfx_tstart,
+            tstep_sym = lfx_tstep, itp = itp, var_sym = :LFX,
+            data_eltype = Float64, live = Ref(true),
+            preloaded_buf = Ref{Any}(nothing))
+        ev = EarthSciData.build_interp_event([info], starttime)
+        aff = ev.affect
+        update_data! = aff.f
+        ctx = aff.ctx
+
+        # Minimal integrator stand-in: the affect only touches `integ.t` and
+        # (defensively, for the auto-prune fallback) `integ.f.sys`.
+        integ = (; t = 6.0 * 3600, f = nothing)
+        nt1 = update_data!(nothing, nothing, ctx, integ)
+        @test nt1 isa NamedTuple
+        nloads1 = fs.nloads[]
+        nt2 = update_data!(nothing, nothing, ctx, integ)
+        @test nt2 === nt1             # identical cached result, same t_abs
+        @test fs.nloads[] == nloads1  # ...and no additional slice reads
+
+        # A genuinely new t_abs (next data interval) rebuilds and reloads.
+        integ2 = (; t = 7.0 * 3600, f = nothing)
+        nt3 = update_data!(nothing, nothing, ctx, integ2)
+        @test nt3 isa NamedTuple
+        @test nt3 !== nt2
+        @test fs.nloads[] > nloads1
+    end
+end

--- a/test/load_test.jl
+++ b/test/load_test.jl
@@ -264,9 +264,12 @@ end
         @test uvals ≈ answers
 
         interp!(itp, buf, times[end], xs[end], xs[end])
-        @test length(itp.cache.times) == 2
-        @test itp.cache.times ==
-              [DateTime("2022-05-02T22:30:00"), DateTime("2022-05-03T01:30:00")]
+        @test length(itp.cache.times) == 3
+        @test itp.cache.times == [
+            DateTime("2022-05-02T19:30:00"),
+            DateTime("2022-05-02T22:30:00"),
+            DateTime("2022-05-03T01:30:00")
+        ]
 
         uvals = zeros(Float32, length(times), length(xs))
         answers = zeros(Float32, length(times), length(xs))
@@ -541,9 +544,12 @@ end
 end
 
 # ---------------------------------------------------------------------------
-# Guard test for the `lazyload!` backward window hysteresis (cache-window
+# Guard test for the `lazyload!` 3-slot lookback window (cache-window
 # thrashing fix). Offline: uses a synthetic FileSet whose `loadslice!`
-# counts how many slices are read from "disk".
+# counts how many slices are read from "disk" and fills each slice with a
+# time-dependent value, so in-window backward queries can be checked
+# against the exact linear interpolant (a constant field could not
+# distinguish linear interpolation from flat extrapolation).
 # ---------------------------------------------------------------------------
 
 struct HysteresisCountFS <: EarthSciData.FileSet
@@ -560,10 +566,11 @@ function EarthSciData.DataFrequencyInfo(
     centerpoints = collect(fs.start:frequency:fs.finish)
     EarthSciData.DataFrequencyInfo(fs.start, frequency, centerpoints)
 end
+_hcfs_tv(fs::HysteresisCountFS, t) = (t - fs.start) / (fs.finish - fs.start)
 function EarthSciData.loadslice!(
         cache::AbstractArray, fs::HysteresisCountFS, t::DateTime, varname)
     fs.nloads[] += 1
-    fill!(cache, 1.0)
+    fill!(cache, _hcfs_tv(fs, t))
 end
 function EarthSciData.loadmetadata(fs::HysteresisCountFS, varname)
     EarthSciData.MetaData(
@@ -573,7 +580,7 @@ function EarthSciData.loadmetadata(fs::HysteresisCountFS, varname)
     )
 end
 
-@testset "lazyload! backward hysteresis: no cache-window thrashing" begin
+@testset "lazyload! 3-slot lookback window: no cache-window thrashing" begin
     domain = DomainInfo(
         DateTime(2024, 1, 1), DateTime(2024, 1, 2);
         lonrange = deg2rad(0.0):deg2rad(1.0):deg2rad(1.0),
@@ -586,31 +593,51 @@ end
     buf = EarthSciData.make_data_buffer(itp)
 
     # Initial load at a centerpoint well inside the dataset: fills the whole
-    # streaming window (2 slots) -> exactly 2 slice reads.
+    # streaming window (3 slots, [ti-1, ti, ti+1]) -> exactly 3 slice reads.
     t0 = DateTime(2024, 1, 1, 6)
     EarthSciData.lazyload!(itp, t0, buf)
-    @test itp.cache.times == [DateTime(2024, 1, 1, 6), DateTime(2024, 1, 1, 7)]
+    @test itp.cache.times ==
+          [DateTime(2024, 1, 1, 5), DateTime(2024, 1, 1, 6), DateTime(2024, 1, 1, 7)]
     n0 = fs.nloads[]
-    @test n0 == 2
+    @test n0 == 3
 
-    # A backward dip of 0.4x the data interval (24 min < half an interval)
-    # stays inside the first loaded centerpoint's bucket: it must be served
-    # by the already-loaded window with NO reload. (This is the thrashing
-    # scenario: per-cell reinit! to the outer-step start time.)
-    t_small = t0 - Minute(24)
-    EarthSciData.lazyload!(itp, t_small, buf)
+    # A backward dip below the anchor centerpoint (24 min = 0.4x the data
+    # interval) is the thrashing scenario: per-cell reinit! to the outer-step
+    # start time. The resident lookback slot must serve it with NO reload...
+    t_dip = t0 - Minute(24)
+    EarthSciData.lazyload!(itp, t_dip, buf)
     @test fs.nloads[] == n0
-    @test itp.cache.times == [DateTime(2024, 1, 1, 6), DateTime(2024, 1, 1, 7)]
-    # The relaxed low-edge assertion serves the dipped time by clamping to
-    # the first slot instead of throwing (field is constant 1.0).
-    @test EarthSciData.interp_unsafe(
-        itp, buf, t_small, itp.grid_starts[1], itp.grid_starts[2]) ≈ 1.0
+    @test itp.cache.times ==
+          [DateTime(2024, 1, 1, 5), DateTime(2024, 1, 1, 6), DateTime(2024, 1, 1, 7)]
+    # ...and — unlike a 2-slot window, which could only flat-extrapolate
+    # here — the lookback slot brackets the dipped time, so the result is the
+    # exact linear interpolation between the 05:00 and 06:00 slices.
+    v5 = _hcfs_tv(fs, DateTime(2024, 1, 1, 5))
+    v6 = _hcfs_tv(fs, DateTime(2024, 1, 1, 6))
+    v_dip = EarthSciData.interp_unsafe(
+        itp, buf, t_dip, itp.grid_starts[1], itp.grid_starts[2])
+    @test v_dip ≈ v5 + 0.6 * (v6 - v5)
 
-    # A backward dip of 0.6x the interval (36 min > half an interval) leaves
-    # the first centerpoint's bucket -> the window must slide back, reading
-    # exactly ONE new slice (the overlapping slot is shifted, not re-read).
-    t_big = t0 - Minute(36)
+    # A solver dipping back and forth across the anchor centerpoint must
+    # cause ZERO reloads while it stays within the window's coverage.
+    for tt in (t0 + Minute(24), t_dip, t0 + Minute(45), t0 - Minute(29))
+        EarthSciData.lazyload!(itp, tt, buf)
+    end
+    @test fs.nloads[] == n0
+
+    # A backward query below the lookback slot (70 min) genuinely leaves the
+    # window: it must slide back, reading exactly ONE new slice (the two
+    # overlapping slots are shifted in place, not re-read).
+    t_big = t0 - Minute(70)
     EarthSciData.lazyload!(itp, t_big, buf)
     @test fs.nloads[] == n0 + 1
-    @test itp.cache.times == [DateTime(2024, 1, 1, 5), DateTime(2024, 1, 1, 6)]
+    @test itp.cache.times ==
+          [DateTime(2024, 1, 1, 4), DateTime(2024, 1, 1, 5), DateTime(2024, 1, 1, 6)]
+
+    # Advancing forward across the window's end also costs exactly ONE slice.
+    n1 = fs.nloads[]
+    EarthSciData.lazyload!(itp, DateTime(2024, 1, 1, 6, 20), buf)
+    @test fs.nloads[] == n1 + 1
+    @test itp.cache.times ==
+          [DateTime(2024, 1, 1, 5), DateTime(2024, 1, 1, 6), DateTime(2024, 1, 1, 7)]
 end

--- a/test/load_test.jl
+++ b/test/load_test.jl
@@ -539,3 +539,78 @@ end
         @test isfinite(val)
     end
 end
+
+# ---------------------------------------------------------------------------
+# Guard test for the `lazyload!` backward window hysteresis (cache-window
+# thrashing fix). Offline: uses a synthetic FileSet whose `loadslice!`
+# counts how many slices are read from "disk".
+# ---------------------------------------------------------------------------
+
+struct HysteresisCountFS <: EarthSciData.FileSet
+    start::DateTime
+    finish::DateTime
+    nloads::Base.RefValue{Int}
+end
+HysteresisCountFS(start, finish) = HysteresisCountFS(start, finish, Ref(0))
+
+function EarthSciData.DataFrequencyInfo(
+        fs::HysteresisCountFS,
+)::EarthSciData.DataFrequencyInfo
+    frequency = Hour(1)
+    centerpoints = collect(fs.start:frequency:fs.finish)
+    EarthSciData.DataFrequencyInfo(fs.start, frequency, centerpoints)
+end
+function EarthSciData.loadslice!(
+        cache::AbstractArray, fs::HysteresisCountFS, t::DateTime, varname)
+    fs.nloads[] += 1
+    fill!(cache, 1.0)
+end
+function EarthSciData.loadmetadata(fs::HysteresisCountFS, varname)
+    EarthSciData.MetaData(
+        [[0.0, 1.0], [0.0, 1.0]],
+        "m", "test", ["x", "y"], [2, 2],
+        "+proj=longlat +datum=WGS84 +no_defs", 1, 2, -1, (false, false, false)
+    )
+end
+
+@testset "lazyload! backward hysteresis: no cache-window thrashing" begin
+    domain = DomainInfo(
+        DateTime(2024, 1, 1), DateTime(2024, 1, 2);
+        lonrange = deg2rad(0.0):deg2rad(1.0):deg2rad(1.0),
+        latrange = deg2rad(0.0):deg2rad(1.0):deg2rad(1.0),
+        levrange = 1:1
+    )
+    fs = HysteresisCountFS(DateTime(2024, 1, 1), DateTime(2024, 1, 2))
+    itp = EarthSciData.DataSetInterpolator{Float64}(
+        fs, "X", DateTime(2024, 1, 1), DateTime(2024, 1, 2), domain)
+    buf = EarthSciData.make_data_buffer(itp)
+
+    # Initial load at a centerpoint well inside the dataset: fills the whole
+    # streaming window (2 slots) -> exactly 2 slice reads.
+    t0 = DateTime(2024, 1, 1, 6)
+    EarthSciData.lazyload!(itp, t0, buf)
+    @test itp.cache.times == [DateTime(2024, 1, 1, 6), DateTime(2024, 1, 1, 7)]
+    n0 = fs.nloads[]
+    @test n0 == 2
+
+    # A backward dip of 0.4x the data interval (24 min < half an interval)
+    # stays inside the first loaded centerpoint's bucket: it must be served
+    # by the already-loaded window with NO reload. (This is the thrashing
+    # scenario: per-cell reinit! to the outer-step start time.)
+    t_small = t0 - Minute(24)
+    EarthSciData.lazyload!(itp, t_small, buf)
+    @test fs.nloads[] == n0
+    @test itp.cache.times == [DateTime(2024, 1, 1, 6), DateTime(2024, 1, 1, 7)]
+    # The relaxed low-edge assertion serves the dipped time by clamping to
+    # the first slot instead of throwing (field is constant 1.0).
+    @test EarthSciData.interp_unsafe(
+        itp, buf, t_small, itp.grid_starts[1], itp.grid_starts[2]) ≈ 1.0
+
+    # A backward dip of 0.6x the interval (36 min > half an interval) leaves
+    # the first centerpoint's bucket -> the window must slide back, reading
+    # exactly ONE new slice (the overlapping slot is shifted, not re-read).
+    t_big = t0 - Minute(36)
+    EarthSciData.lazyload!(itp, t_big, buf)
+    @test fs.nloads[] == n0 + 1
+    @test itp.cache.times == [DateTime(2024, 1, 1, 5), DateTime(2024, 1, 1, 6)]
+end


### PR DESCRIPTION

**perf · non-breaking · stacked on the companion 3-slot lookback-window PR**

## Motivation
Under threaded Strang, every per-cell inner step calls `lazyload!` on every interpolator and fires the interp-event affect, and both serialize on shared locks: each cell contended `itp.lock` even when the loaded window already covered `t` (the overwhelmingly common case — a reload is only possible once per data interval), and the per-tstop affect rebuilt the parameter NamedTuple and re-locked once per cell. The result is a hard scaling wall: a 10-thread Strang CTM ran no faster than 4 threads. Author-side integration evidence (not reproducible from this repo): removing both serialization points took a coupled CONUS run from 25 to 13 s/sim-hour at 10 threads, restoring positive thread scaling. The `bench/runbenchmarks.jl` threaded-Strang CONUS NEI benchmark exercises the same path in-repo.

## Change
- `lazyload!`: lock-free fast path — when the cached `times` window already covers `t`, return without touching `itp.lock`.
- interp-event affect: cache the built parameter NamedTuple keyed by the absolute time it was built for (`last_tabs`); a repeat fire at the same `t_abs` returns the cached tuple with no lock and no allocation (double-checked under the lock for the racing first build).

## Why this departs from the current design
Upstream acquires `itp.lock` on every `lazyload!` call and rebuilds the affect result on every fire — correct by construction, but the locks are shared across all solver threads, so they become the bottleneck precisely when no reload is needed.

- **The unsynchronized fast-path read is a benign race.** `tc.times`/`tc.initialized` are mutated only inside `update!` under the lock, and `DateTime`s are immutable, so a stale read cannot observe a torn value; it can only fail conservative — falling through to the locked slow path, which re-checks under the lock. When the read shows the window covering `t`, no reload is possible, so skipping the lock cannot skip needed work. The fast-path guard mirrors the slow-path reload condition exactly (the exact window-coverage check of the stack-base 3-slot-window PR).
- **The affect cache changes no observable result.** Under `SolverStrangThreads` every grid cell's `reinit!` fires the affect at the SAME `t_abs` within one outer step, so the built NamedTuple is identical across those fires; the cache key is the exact `t_abs`, and a genuinely new time rebuilds under the lock. The pre-existing per-fire NamedTuple allocation is also removed for repeat fires.

## Validation
- New offline testsets in `load_test.jl` (counting-`FileSet` fixture): repeated `lazyload!` at an unchanged or window-covered time performs zero reloads; the affect returns the identical (`===`) NamedTuple for a repeated `t_abs` with no additional slice reads, and a new `t_abs` (next data interval) rebuilds and reloads. These offline testsets are the validation of record.
- Full `load_test.jl` green on this branch **rebased onto the 3-slot lookback-window fix** — including the interpolation order-independence and analytic-truth testsets that gated the earlier 2-slot variant of the stack base.
- Author-side integration evidence (not reproducible from this repo; measured on the interim 2-slot window logic): a coupled CONUS run improved from 25 to 13 s/sim-hour at 10 threads. The lock-free fast path itself is window-model-agnostic (it mirrors whatever the slow-path coverage check is), so the mechanism carries over to the 3-slot window unchanged; the in-repo no-reload/identity guards above pin it.

---

### Review order - part of the coordinated train ([EarthSciML/GasChem.jl#225](https://github.com/EarthSciML/GasChem.jl/issues/225))

Base = `main`. **Stacked on the 3-slot lookback-window PR (#219)**: the diff vs `main` includes #219's commits; net-new here = the lock-free fast path + affect-cache commits. Shrinks once #219 merges. Merge after #219.

*Part of the coordinated cross-repo update tracked in EarthSciML/GasChem.jl#225.*
