### PR TITLE
Interpolate non-uniform grid axes on their true knots (GEOS-FP half-polar latitude was silently displaced ~2-4 km)

### DIFF
--- a/src/landfire.jl
+++ b/src/landfire.jl
@@ -188,9 +188,7 @@ instead of `BSpline(Linear())`.
 function _nearest_interpolate_from!(dst::AbstractArray{T, 2},
         src::AbstractArray{T, 2}, mta::MetaData, model_grid, domain;
         extrapolate_type = Flat()) where {T}
-    data_grid = Tuple(knots2range.(mta.coords))
-    itp = interpolate!(src, BSpline(Constant()))
-    itp = extrapolate(scale(itp, data_grid), extrapolate_type)
+    itp = _build_regrid_interp(src, mta.coords, extrapolate_type, Constant())
     ct = coord_trans(mta, domain)
     for (i, x) in enumerate(model_grid[1])
         for (j, y) in enumerate(model_grid[2])

--- a/src/load.jl
+++ b/src/load.jl
@@ -490,6 +490,18 @@ function Base.show(io::IO, itp::DataSetInterpolator)
 end
 
 """
+Return `true` if `knots` are evenly spaced to within relative tolerance `reltol`.
+Non-uniform axes (e.g. the GEOS-FP latitude grid, whose polar rows are half-size)
+must NOT be forced onto a uniform range — use gridded interpolation instead.
+"""
+function isuniform(knots, reltol = 0.05)
+    length(knots) <= 2 && return true
+    dx = diff(knots)
+    dx_mean = sum(dx) / length(dx)
+    all(abs.(1 .- dx ./ dx_mean) .<= reltol)
+end
+
+"""
 Convert a vector of evenly spaced grid points to a range.
 The `reltol` parameter specifies the relative tolerance for the grid spacing,
 which is necessary to account for different numbers of days in each month
@@ -499,9 +511,12 @@ function knots2range(knots, reltol = 0.05)
     if length(knots) == 1
         return knots[begin]:one(eltype(knots)):knots[begin]
     end
-    dx = diff(knots)
-    dx_mean = sum(dx) / length(dx)
-    #@assert all(abs.(1 .- dx ./ dx_mean) .<= reltol) "Knots ($knots) must be evenly spaced within reltol=$reltol."
+    # This guard was previously commented out, which let the GEOS-FP half-polar
+    # latitude axis (spacings {0.1875, 0.25} deg) be silently uniformized to
+    # 0.24983 deg — displacing every met field northward by +1.9 km (25N) to
+    # +3.8 km (49N) and blending 7-14% with the neighbouring native row.
+    # Callers must check `isuniform` first and take a Gridded path otherwise.
+    @assert isuniform(knots, reltol) "Knots ($knots) must be evenly spaced within reltol=$reltol; use gridded interpolation for non-uniform axes."
     dx = (knots[end] - knots[begin]) / (length(knots) - 1)
     # Need to do weird range creation to avoid rounding errors.
     return knots[begin]:dx:(knots[begin] + dx * (length(knots) - 1))

--- a/src/regridding.jl
+++ b/src/regridding.jl
@@ -49,13 +49,31 @@ function regrid_horizontal!(dst_field, regridder::ConservativeRegridding.Regridd
     reshape(dst_field, sz...)
 end
 
+"""
+Build the source-grid interpolator for regridding. Uniform axes take the fast
+scaled-BSpline path; any non-uniform axis (e.g. the GEOS-FP half-polar latitude
+grid, spacings {0.1875, 0.25} deg) switches to `Gridded` interpolation on the
+true knots. Forcing a uniform range onto that axis displaced every met field
+poleward by up to ~4 km and blended 7-14% with the neighbouring native row.
+"""
+function _build_regrid_interp(src, coords, extrapolate_type, degree = Linear())
+    if all(c -> isuniform(c), coords)
+        data_grid = Tuple(knots2range.(coords))
+        padded_src, padded_grid = _pad_singletons(src, data_grid)
+        itp0 = interpolate!(padded_src, BSpline(degree))
+        return extrapolate(scale(itp0, padded_grid), extrapolate_type)
+    else
+        knots = Tuple(collect(Float64, c) for c in coords)
+        padded_src, padded_knots = _pad_singletons(src, knots)
+        return extrapolate(
+            interpolate(padded_knots, padded_src, Gridded(degree)), extrapolate_type)
+    end
+end
+
 function interpolate_from!(dst::AbstractArray{T, N},
         src::AbstractArray{T, N}, mta::MetaData, model_grid, domain;
         extrapolate_type = Flat()) where {T, N}
-    data_grid = Tuple(knots2range.(mta.coords))
-    padded_src, padded_grid = _pad_singletons(src, data_grid)
-    itp = interpolate!(padded_src, BSpline(Linear()))
-    itp = extrapolate(scale(itp, padded_grid), extrapolate_type)
+    itp = _build_regrid_interp(src, mta.coords, extrapolate_type)
     ct = coord_trans(mta, domain)
     if N == 3
         for (i, x) in enumerate(model_grid[1])

--- a/test/regridding.jl
+++ b/test/regridding.jl
@@ -11,4 +11,31 @@ using Test
         d2 = EarthSciData.data2vecormat(d, 2, 1)
         @test size(d2) == (6,)
     end
+
+    @testset "non-uniform axis (GEOS-FP half-polar latitude)" begin
+        # True GEOS-FP 0.25x0.3125 latitude axis: half-size polar rows give
+        # spacings {0.1875, 0.25} deg -- NOT uniform.
+        lat = [-89.9375; collect(-89.75:0.25:89.75); 89.9375]
+        lon = collect(0.0:0.3125:3.125)
+        f(x, y) = 2y + 0.01y^2
+        src = [f(x, y) for x in lon, y in lat]
+
+        @test !EarthSciData.isuniform(lat)
+        @test EarthSciData.isuniform(collect(-90.0:4.0:90.0))
+        # forcing a range onto the non-uniform axis must now be an error,
+        # not silent corruption
+        @test_throws AssertionError EarthSciData.knots2range(lat)
+
+        itp = EarthSciData._build_regrid_interp(
+            copy(src), [lon, lat], EarthSciData.Flat())
+        # Exact reproduction at the native knots. The previous uniformized-range
+        # path was off by ~0.078 here (a ~3 km poleward displacement at 40N).
+        @test itp(lon[2], 40.0) ≈ f(lon[2], 40.0) atol = 1.0e-12
+        @test itp(lon[2], 25.0) ≈ f(lon[2], 25.0) atol = 1.0e-12
+        @test itp(lon[2], -89.9375) ≈ f(lon[2], -89.9375) atol = 1.0e-12
+        # uniform axes still take the fast path and reproduce knots exactly
+        itp_u = EarthSciData._build_regrid_interp(
+            copy(src[:, 2:42]), [lon, collect(-89.75:0.25:-79.75)], EarthSciData.Flat())
+        @test itp_u(lon[2], -85.0) ≈ f(lon[2], -85.0) atol = 1.0e-12
+    end
 end


### PR DESCRIPTION
## Summary

`knots2range` silently forces every coordinate axis onto a uniform range — and the guard that would have caught a non-uniform axis is **commented out**. The GEOS-FP latitude grid has **half-size polar rows** (spacings `{0.1875, 0.25}`° for the 0.25×0.3125 product; guard metric 0.2495 vs its own 0.05 threshold, 5× over), so the axis was uniformized to 0.24983° — **displacing every met field (winds, PBLH, T, precip, PS) poleward by +1.9 km (25°N) to +3.8 km (49°N)** and blending 7–14% with the neighbouring native row. Measured RMS vs exact sampling on real 2016-04-09 CONUS data: U 2.7%, PBLH 14 m, T2M 0.12 K.

The decisive symptom: the old path is wrong **at the native knots themselves** — on a slope-2 test field it errs by 0.078 at 40°N (a ~3 km effective shift), where an interpolator should be exact.

## Change

- **`isuniform(knots, reltol)`** — explicit uniformity predicate; `knots2range` now asserts it, so any future non-uniform axis reaching the uniform path fails loudly instead of silently corrupting.
- **`_build_regrid_interp(src, coords, extrapolate_type, degree)`** — uniform axes keep the fast scaled-BSpline path (**bit-identical** to before); any non-uniform axis switches to `Gridded` interpolation on the true knots. Used by `interpolate_from!` and the LANDFIRE nearest-neighbour variant.
- **Regression test** — the true GEOS-FP half-polar axis must reproduce knot values exactly (old: 0.078 error; new: 0.0), `knots2range` must throw on it, and uniform axes must keep the fast path. 9/9 pass locally.

## Why existing pinned tests are unaffected

The geosfp test suite uses the **4×5** product, whose latitude axis **is** uniform (all spacings 4.0° — verified on the real file), so those tests take the unchanged fast path and their pinned values hold. Only 0.25°/0.5° production runs change — by design, toward correctness.

Found by a numerical equivalence audit of this stack against GEOS-Chem Classic 14.7.1 (GC handles the half-polar rows explicitly). Part of the Stage-6 series in EarthSciML/GasChem.jl#225.